### PR TITLE
Add offline support

### DIFF
--- a/demo/src/rise-data-rss.html
+++ b/demo/src/rise-data-rss.html
@@ -39,12 +39,19 @@
       max-items="15">
   </rise-data-rss>
 
+  <div id="rssTitles"></div>
+
   <script>
     function configureComponents() {
       const riseDataRSS01 = document.querySelector('#rise-data-rss-01');
 
       riseDataRSS01.addEventListener("data-update", data => {
         console.log("Received feed-parser data", data);
+
+        var header = "<h3>Response received at: " + new Date() + "</h3>";
+        var titles = data.detail.map(item => { return "<p>" + item.title + "</p>"; }).join("");
+
+        document.querySelector('#rssTitles').innerHTML = header + titles;
       });
 
       riseDataRSS01.addEventListener("data-error", error => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -986,8 +986,8 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#0360619d00cf3db935e891d89956226d994b7ef3",
-      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.7",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#6d1b1be5337f2d090c4e072805d40021a80736ee",
+      "from": "git://github.com/Rise-Vision/rise-common-component.git#feature/offline-play",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "^2.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -986,8 +986,8 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#6d1b1be5337f2d090c4e072805d40021a80736ee",
-      "from": "git://github.com/Rise-Vision/rise-common-component.git#feature/offline-play",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#3f170696284bc67ed568a8ce3049dc82145d9d51",
+      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.8",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "^2.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -986,8 +986,8 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#4d40c282814550483ef556d2fed8d5af1ebc1d49",
-      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.1",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#0360619d00cf3db935e891d89956226d994b7ef3",
+      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.7",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "^2.1.3"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#6d1b1be",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#140e2b6",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#3e749d4",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.8",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#feature/offline-play",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#6d1b1be",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.7",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#feature/offline-play",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.1",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.7",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#667e478",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#3e749d4",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#140e2b6",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#667e478",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -62,13 +62,12 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
     super.initFetch({
       refresh: 1000 * 60,
       retry: 1000 * 60,
-      cooldown: 1000 * 60 * 10,
-      useCacheIfOffline: true
+      cooldown: 1000 * 60 * 10
     }, this._handleResponse, this._handleError);
 
     super.initCache({
       name: this.tagName.toLowerCase(),
-      preserveExpired: true
+      expiry: -1
     });    
   }
 
@@ -128,8 +127,10 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
   _handleFetchError(err) {
     let error = err ? err.message : null;
 
-    super.log("error", "rss-request-error", { error });
-    this._sendRssEvent(RiseDataRss.EVENT_REQUEST_ERROR, { error });
+    if (!(err && err.isOffline)) {
+      super.log("error", "rss-request-error", { error });
+      this._sendRssEvent(RiseDataRss.EVENT_REQUEST_ERROR, { error });
+    }
   }
 
   _sendRssEvent(name, detail) {

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -115,6 +115,8 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
     else {
       let error = data.Error;
 
+      this.log( "error", "data error", { error });
+
       this._sendRssEvent(RiseDataRss.EVENT_DATA_ERROR, { error });
     }
   }

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -59,9 +59,16 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
   ready() {
     super.ready();
 
-    super.initFetch({}, this._handleResponse, this._handleError);
+    super.initFetch({
+      refresh: 1000 * 60,
+      retry: 1000 * 60,
+      cooldown: 1000 * 60 * 10,
+      useCacheIfOffline: true
+    }, this._handleResponse, this._handleError);
+
     super.initCache({
-      name: this.tagName.toLowerCase()
+      name: this.tagName.toLowerCase(),
+      preserveExpired: true
     });    
   }
 

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -60,8 +60,8 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
     super.ready();
 
     super.initFetch({
-      refresh: 1000 * 60,
-      retry: 1000 * 60,
+      refresh: 1000 * 60 * 5,
+      retry: 1000 * 60 * 5,
       cooldown: 1000 * 60 * 10
     }, this._handleResponse, this._handleError);
 

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -77,8 +77,6 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
     if (this._initialStart) {
       this._initialStart = false;
 
-      super.log("info", "rss-start");
-
       if (this.feedUrl) {
         this._loadFeedData();
       }
@@ -103,8 +101,7 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
 
   _handleResponse(response) {
     response.json()
-      .then(this._processRssData.bind(this))
-      .catch(this._handleFetchError.bind(this));
+      .then(this._processRssData.bind(this));
   }
 
   _processRssData(data) {
@@ -112,23 +109,20 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
       if (!isEqual(this.feedData, data)) {
         this._setFeedData(data.slice(0, this.maxItems));
 
-        super.log("info", "rss-data-update", {});
         this._sendRssEvent(RiseDataRss.EVENT_DATA_UPDATE, this.feedData);
       }
     }
     else {
       let error = data.Error;
 
-      super.log("error", "rss-data-error", { error });
       this._sendRssEvent(RiseDataRss.EVENT_DATA_ERROR, { error });
     }
   }
 
-  _handleFetchError(err) {
+  _handleError(err) {
     let error = err ? err.message : null;
 
     if (!(err && err.isOffline)) {
-      super.log("error", "rss-request-error", { error });
       this._sendRssEvent(RiseDataRss.EVENT_REQUEST_ERROR, { error });
     }
   }

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -1,9 +1,14 @@
 import { RiseElement } from "rise-common-component/src/rise-element.js";
+import { CacheMixin } from "rise-common-component/src/cache-mixin.js";
+import { FetchMixin } from "rise-common-component/src/fetch-mixin.js";
+
 import { rssConfig } from "./rise-data-rss-config.js";
 import { version } from "./rise-data-rss-version.js";
 import isEqual from "lodash-es/isEqual";
 
-export default class RiseDataRss extends RiseElement {
+const fetchBase = CacheMixin( RiseElement );
+
+export default class RiseDataRss extends FetchMixin(fetchBase) {
 
   static get properties() {
     return {
@@ -51,14 +56,13 @@ export default class RiseDataRss extends RiseElement {
     this._initialStart = true;
   }
 
-  _getUrl() {
-    return rssConfig.feedParserURL + "/" + this.feedUrl;
-  }
+  ready() {
+    super.ready();
 
-  _feedUrlChanged() {
-    if (!this._initialStart && this.feedUrl) {
-      this._requestData();
-    }
+    super.initFetch({}, this._handleResponse, this._handleError);
+    super.initCache({
+      name: this.tagName.toLowerCase()
+    });    
   }
 
   _handleStart() {
@@ -70,41 +74,47 @@ export default class RiseDataRss extends RiseElement {
       super.log("info", "rss-start");
 
       if (this.feedUrl) {
-        this._requestData();
+        this._loadFeedData();
       }
     }
   }
 
-  _requestData() {
-    fetch(this._getUrl(), {
-      headers: { "X-Requested-With": "rise-data-rss" }
-    })
-    .then(resp => {
-      return resp.json();
-    })
-    .then(data => {
-      this._handleResponse(data);
-    })
-    .catch(err => {
-      this._handleFetchError(err);
-    });
+  _getUrl() {
+    return rssConfig.feedParserURL + "/" + this.feedUrl;
   }
 
-  _handleResponse(data) {
+  _feedUrlChanged() {
+    this._loadFeedData();
+  }
+
+  _loadFeedData() {
+    if (!this._initialStart && this.feedUrl) {
+      super.fetch(this._getUrl(), {
+        headers: { "X-Requested-With": "rise-data-rss" }
+      });
+    }
+  }
+
+  _handleResponse(response) {
+    response.json()
+      .then(this._processRssData.bind(this))
+      .catch(this._handleFetchError.bind(this));
+  }
+
+  _processRssData(data) {
     if (!data.Error) {
-      // Temporary solution; this should use a more robust comparison method such as deep-equal
       if (!isEqual(this.feedData, data)) {
         this._setFeedData(data.slice(0, this.maxItems));
 
         super.log("info", "rss-data-update", {});
-        this._sendEvent(RiseDataRss.EVENT_DATA_UPDATE, this.feedData);
+        this._sendRssEvent(RiseDataRss.EVENT_DATA_UPDATE, this.feedData);
       }
     }
     else {
       let error = data.Error;
 
       super.log("error", "rss-data-error", { error });
-      this._sendEvent(RiseDataRss.EVENT_DATA_ERROR, { error });
+      this._sendRssEvent(RiseDataRss.EVENT_DATA_ERROR, { error });
     }
   }
 
@@ -112,7 +122,22 @@ export default class RiseDataRss extends RiseElement {
     let error = err ? err.message : null;
 
     super.log("error", "rss-request-error", { error });
-    this._sendEvent(RiseDataRss.EVENT_REQUEST_ERROR, { error });
+    this._sendRssEvent(RiseDataRss.EVENT_REQUEST_ERROR, { error });
+  }
+
+  _sendRssEvent(name, detail) {
+    super._sendEvent(name, detail);
+
+    switch (name) {
+    case RiseDataRss.EVENT_REQUEST_ERROR:
+    case RiseDataRss.EVENT_DATA_ERROR:
+      super._setUptimeError(true);
+      break;
+    case RiseDataRss.EVENT_DATA_UPDATE:
+      super._setUptimeError(false);
+      break;
+    default:
+    }
   }
 }
 

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -109,6 +109,8 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
       if (!isEqual(this.feedData, data)) {
         this._setFeedData(data.slice(0, this.maxItems));
 
+        this.log( "info", "data provided" );
+
         this._sendRssEvent(RiseDataRss.EVENT_DATA_UPDATE, this.feedData);
       }
     }

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -48,16 +48,19 @@
         };
         let sandbox = sinon.createSandbox();
         let element;
-        let logger;
+        let fetchMixin, cacheMixin, loggerMixin;
 
         setup(() => {
           element = fixture("test-block");
 
-          // RiseDataRss => RiseElement => LoggerMixin
-          logger = element.__proto__.__proto__.__proto__;
+          // RiseDataRss => RiseFetchMixin => RiseCacheMixin => RiseElement => LoggerMixin
+          fetchMixin = element.__proto__.__proto__;
+          cacheMixin = element.__proto__.__proto__.__proto__;
+          loggerMixin = element.__proto__.__proto__.__proto__.__proto__.__proto__;
 
-          sandbox.stub(logger, "initLogger");
-          sandbox.stub(logger, "log");
+          sandbox.stub(cacheMixin, "initCache");
+          sandbox.stub(loggerMixin, "initLogger");
+          sandbox.stub(loggerMixin, "log");
           sandbox.stub(window, "fetch");
         });
 
@@ -116,33 +119,55 @@
 
         suite("'start' event", () => {
           test("should request data only after start has been called", done => {
-            sandbox.stub(element, "_requestData");
+            sandbox.stub(fetchMixin, "fetch");
 
             element.feedUrl = "sampleFeedUrl";
 
             setTimeout(() => {
-              assert.isFalse(element._requestData.called);
+              assert.isFalse(fetchMixin.fetch.called);
 
               element.dispatchEvent(new CustomEvent("start"));
 
               setTimeout(() => {
-                assert.isTrue(element._requestData.called);
+                assert.isTrue(fetchMixin.fetch.called);
                 done();
               });
             });
           });
         });
 
-        suite("_requestData", () => {
+        suite("_loadFeedData", () => {
           let response;
 
           setup(() => {
-            sandbox.stub(element, "_sendEvent");
+            sandbox.stub(cacheMixin, "putCache").resolves();
+            sandbox.stub(element, "_sendRssEvent");
+            sandbox.stub(element, "_setUptimeError");
 
             element.dispatchEvent(new CustomEvent("start"));
           });
 
+          test("should handle a valid response from cache", done => {
+            sandbox.stub(cacheMixin, "getCache").resolves(new Response(JSON.stringify(validRssJson)));
+
+            element.feedUrl = sampleFeedUrl;
+
+            setTimeout(() => {
+              assert.isFalse(window.fetch.called);
+
+              // Should log the received data
+              assert.equal(element.log.getCall(3).args[1], "rss-data-update");
+              assert.deepEqual(element.log.getCall(3).args[2], {});
+              // Should send a data-update event
+              assert.equal(element._sendRssEvent.getCall(0).args[0], "data-update");
+              assert.deepEqual(element._sendRssEvent.getCall(0).args[1], validRssJson);
+
+              done();
+            }, 30);
+          });
+
           test("should handle a valid response from feed-parser", done => {
+            sandbox.stub(cacheMixin, "getCache").rejects();
             window.fetch.resolves(new Response(JSON.stringify(validRssJson)));
 
             element.feedUrl = sampleFeedUrl;
@@ -152,14 +177,14 @@
               assert.equal(window.fetch.args[0][0], sampleServerUrl + sampleFeedUrl);
 
               // Should log the received data
-              assert.equal(element.log.getCall(2).args[1], "rss-data-update");
-              assert.deepEqual(element.log.getCall(2).args[2], {});
+              assert.equal(element.log.getCall(3).args[1], "rss-data-update");
+              assert.deepEqual(element.log.getCall(3).args[2], {});
               // Should send a data-update event
-              assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
-              assert.deepEqual(element._sendEvent.getCall(0).args[1], validRssJson);
+              assert.equal(element._sendRssEvent.getCall(0).args[0], "data-update");
+              assert.deepEqual(element._sendRssEvent.getCall(0).args[1], validRssJson);
 
               done();
-            });
+            }, 30);
           });
 
           test("should only return the first 15 valid items", done => {
@@ -169,6 +194,7 @@
               }
             });
 
+            sandbox.stub(cacheMixin, "getCache").rejects();
             window.fetch.resolves(new Response(JSON.stringify(largeRssJson)));
 
             element.maxItems = 15;
@@ -178,18 +204,21 @@
               assert.isTrue(window.fetch.called);
               assert.equal(window.fetch.args[0][0], sampleServerUrl + sampleFeedUrl);
 
-              // Should log the received data
-              assert.equal(element.log.getCall(2).args[1], "rss-data-update");
-              assert.deepEqual(element.log.getCall(2).args[2], {});
-              // Should send a data-update event
-              assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
-              assert.deepEqual(element._sendEvent.getCall(0).args[1], largeRssJson.slice(0, 15));
+              setTimeout(() => {
+                // Should log the received data
+                assert.equal(element.log.getCall(3).args[1], "rss-data-update");
+                assert.deepEqual(element.log.getCall(3).args[2], {});
+                // Should send a data-update event
+                assert.equal(element._sendRssEvent.getCall(0).args[0], "data-update");
+                assert.deepEqual(element._sendRssEvent.getCall(0).args[1], largeRssJson.slice(0, 15));
 
-              done();
+                done();
+              }, 20);
             });
           });
 
           test("should handle an invalid response from feed-parser", done => {
+            sandbox.stub(cacheMixin, "getCache").rejects();
             window.fetch.resolves(new Response(JSON.stringify(invalidRssJson)));
 
             element.feedUrl = sampleFeedUrl;
@@ -198,20 +227,23 @@
               assert.isTrue(window.fetch.called);
               assert.equal(window.fetch.args[0][0], sampleServerUrl + sampleFeedUrl);
 
-              // Should log the received data
-              assert.equal(element.log.getCall(2).args[1], "rss-data-error");
-              assert.deepEqual(element.log.getCall(2).args[2], { error: invalidRssJson.Error });
-              // Should send a data-update event
-              assert.equal(element._sendEvent.getCall(0).args[0], "data-error");
-              assert.deepEqual(element._sendEvent.getCall(0).args[1], { error: invalidRssJson.Error });
+              setTimeout(() => {
+                // Should log the received data
+                assert.equal(element.log.getCall(3).args[1], "rss-data-error");
+                assert.deepEqual(element.log.getCall(3).args[2], { error: invalidRssJson.Error });
+                // Should send a data-update event
+                assert.equal(element._sendRssEvent.getCall(0).args[0], "data-error");
+                assert.deepEqual(element._sendRssEvent.getCall(0).args[1], { error: invalidRssJson.Error });
 
-              done();
+                done();
+              }, 20);
             });
           });
 
           test("should handle failure to connect to feed-parser", done => {
             let errorMessage = "Failed to connect to feed-parser";
 
+            sandbox.stub(cacheMixin, "getCache").rejects();
             window.fetch.rejects({ message: errorMessage });
 
             element.feedUrl = sampleFeedUrl;
@@ -219,14 +251,16 @@
             setTimeout(() => {
               assert.isTrue(window.fetch.called);
 
-              // Should log the request error data
-              assert.equal(element.log.getCall(2).args[1], "rss-request-error");
-              assert.deepEqual(element.log.getCall(2).args[2], { error: errorMessage });
-              // Should send a request-error event
-              assert.equal(element._sendEvent.getCall(0).args[0], "request-error");
-              assert.deepEqual(element._sendEvent.getCall(0).args[1], { error: errorMessage });
+              setTimeout(() => {
+                // Should log the request error data
+                assert.equal(element.log.getCall(2).args[1], "rss-request-error");
+                assert.deepEqual(element.log.getCall(2).args[2], { error: errorMessage });
+                // Should send a request-error event
+                assert.equal(element._sendRssEvent.getCall(0).args[0], "request-error");
+                assert.deepEqual(element._sendRssEvent.getCall(0).args[1], { error: errorMessage });
 
-              done();
+                done();
+              }, 20);
             });
           });
         });

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -182,6 +182,8 @@
               // Should log the received data
               assert.equal(element.log.getCall(1).args[1], "data received");
               assert.deepEqual(element.log.getCall(1).args[2], { cached: false });
+              // Should log that it provided new data to the client
+              assert.equal(element.log.getCall(2).args[1], "data provided");
               // Should send a data-update event
               assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
               assert.deepEqual(element._sendEvent.getCall(0).args[1], validRssJson);

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -48,7 +48,7 @@
         };
         let sandbox = sinon.createSandbox();
         let element;
-        let fetchMixin, cacheMixin, loggerMixin;
+        let fetchMixin, cacheMixin, riseElement, loggerMixin;
 
         setup(() => {
           element = fixture("test-block");
@@ -56,8 +56,11 @@
           // RiseDataRss => RiseFetchMixin => RiseCacheMixin => RiseElement => LoggerMixin
           fetchMixin = element.__proto__.__proto__;
           cacheMixin = element.__proto__.__proto__.__proto__;
+          riseElement = element.__proto__.__proto__.__proto__.__proto__;
           loggerMixin = element.__proto__.__proto__.__proto__.__proto__.__proto__;
 
+          sandbox.spy(riseElement, '_sendEvent');
+          sandbox.stub(riseElement, '_setUptimeError');
           sandbox.stub(loggerMixin, "initLogger");
           sandbox.stub(loggerMixin, "log");
           sandbox.stub(window, "fetch");
@@ -140,8 +143,6 @@
 
           setup(() => {
             sandbox.stub(cacheMixin, "putCache").resolves();
-            sandbox.stub(element, "_sendRssEvent");
-            sandbox.stub(element, "_setUptimeError");
 
             element.dispatchEvent(new CustomEvent("start"));
           });
@@ -152,14 +153,15 @@
             element.feedUrl = sampleFeedUrl;
 
             setTimeout(() => {
+              assert.isTrue(riseElement._setUptimeError.calledWith(false));
               assert.isFalse(window.fetch.called);
 
               // Should log the received data
               assert.equal(element.log.getCall(3).args[1], "rss-data-update");
               assert.deepEqual(element.log.getCall(3).args[2], {});
               // Should send a data-update event
-              assert.equal(element._sendRssEvent.getCall(0).args[0], "data-update");
-              assert.deepEqual(element._sendRssEvent.getCall(0).args[1], validRssJson);
+              assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
+              assert.deepEqual(element._sendEvent.getCall(0).args[1], validRssJson);
 
               done();
             }, 30);
@@ -172,6 +174,8 @@
             element.feedUrl = sampleFeedUrl;
 
             setTimeout(() => {
+              assert.isTrue(riseElement._setUptimeError.calledWith(false));
+
               assert.isTrue(window.fetch.called);
               assert.equal(window.fetch.args[0][0], sampleServerUrl + sampleFeedUrl);
 
@@ -179,8 +183,8 @@
               assert.equal(element.log.getCall(3).args[1], "rss-data-update");
               assert.deepEqual(element.log.getCall(3).args[2], {});
               // Should send a data-update event
-              assert.equal(element._sendRssEvent.getCall(0).args[0], "data-update");
-              assert.deepEqual(element._sendRssEvent.getCall(0).args[1], validRssJson);
+              assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
+              assert.deepEqual(element._sendEvent.getCall(0).args[1], validRssJson);
 
               done();
             }, 30);
@@ -204,12 +208,14 @@
               assert.equal(window.fetch.args[0][0], sampleServerUrl + sampleFeedUrl);
 
               setTimeout(() => {
+                assert.isTrue(riseElement._setUptimeError.calledWith(false));
+
                 // Should log the received data
                 assert.equal(element.log.getCall(3).args[1], "rss-data-update");
                 assert.deepEqual(element.log.getCall(3).args[2], {});
                 // Should send a data-update event
-                assert.equal(element._sendRssEvent.getCall(0).args[0], "data-update");
-                assert.deepEqual(element._sendRssEvent.getCall(0).args[1], largeRssJson.slice(0, 15));
+                assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
+                assert.deepEqual(element._sendEvent.getCall(0).args[1], largeRssJson.slice(0, 15));
 
                 done();
               }, 20);
@@ -227,12 +233,14 @@
               assert.equal(window.fetch.args[0][0], sampleServerUrl + sampleFeedUrl);
 
               setTimeout(() => {
+                assert.isTrue(riseElement._setUptimeError.calledWith(true));
+
                 // Should log the received data
                 assert.equal(element.log.getCall(3).args[1], "rss-data-error");
                 assert.deepEqual(element.log.getCall(3).args[2], { error: invalidRssJson.Error });
                 // Should send a data-update event
-                assert.equal(element._sendRssEvent.getCall(0).args[0], "data-error");
-                assert.deepEqual(element._sendRssEvent.getCall(0).args[1], { error: invalidRssJson.Error });
+                assert.equal(element._sendEvent.getCall(0).args[0], "data-error");
+                assert.deepEqual(element._sendEvent.getCall(0).args[1], { error: invalidRssJson.Error });
 
                 done();
               }, 20);
@@ -251,12 +259,14 @@
               assert.isTrue(window.fetch.called);
 
               setTimeout(() => {
+                assert.isTrue(riseElement._setUptimeError.calledWith(true));
+
                 // Should log the request error data
                 assert.equal(element.log.getCall(2).args[1], "rss-request-error");
                 assert.deepEqual(element.log.getCall(2).args[2], { error: errorMessage });
                 // Should send a request-error event
-                assert.equal(element._sendRssEvent.getCall(0).args[0], "request-error");
-                assert.deepEqual(element._sendRssEvent.getCall(0).args[1], { error: errorMessage });
+                assert.equal(element._sendEvent.getCall(0).args[0], "request-error");
+                assert.deepEqual(element._sendEvent.getCall(0).args[1], { error: errorMessage });
 
                 done();
               }, 20);
@@ -278,6 +288,8 @@
             element.feedUrl = sampleFeedUrl;
 
             setTimeout(() => {
+              assert.isTrue(riseElement._setUptimeError.calledWith(false));
+
               assert.isTrue(window.fetch.called);
               assert.equal(window.fetch.args[0][0], sampleServerUrl + sampleFeedUrl);
 
@@ -285,8 +297,8 @@
               assert.equal(element.log.getCall(2).args[1], "rss-data-update");
               assert.deepEqual(element.log.getCall(2).args[2], {});
               // Should send a data-update event
-              assert.equal(element._sendRssEvent.getCall(0).args[0], "data-update");
-              assert.deepEqual(element._sendRssEvent.getCall(0).args[1], validRssJson);
+              assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
+              assert.deepEqual(element._sendEvent.getCall(0).args[1], validRssJson);
 
               done();
             }, 30);

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -157,8 +157,8 @@
               assert.isFalse(window.fetch.called);
 
               // Should log the received data
-              assert.equal(element.log.getCall(3).args[1], "rss-data-update");
-              assert.deepEqual(element.log.getCall(3).args[2], {});
+              assert.equal(element.log.getCall(1).args[1], "data received");
+              assert.deepEqual(element.log.getCall(1).args[2], { cached: true });
               // Should send a data-update event
               assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
               assert.deepEqual(element._sendEvent.getCall(0).args[1], validRssJson);
@@ -180,8 +180,8 @@
               assert.equal(window.fetch.args[0][0], sampleServerUrl + sampleFeedUrl);
 
               // Should log the received data
-              assert.equal(element.log.getCall(3).args[1], "rss-data-update");
-              assert.deepEqual(element.log.getCall(3).args[2], {});
+              assert.equal(element.log.getCall(1).args[1], "data received");
+              assert.deepEqual(element.log.getCall(1).args[2], { cached: false });
               // Should send a data-update event
               assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
               assert.deepEqual(element._sendEvent.getCall(0).args[1], validRssJson);
@@ -211,8 +211,8 @@
                 assert.isTrue(riseElement._setUptimeError.calledWith(false));
 
                 // Should log the received data
-                assert.equal(element.log.getCall(3).args[1], "rss-data-update");
-                assert.deepEqual(element.log.getCall(3).args[2], {});
+                assert.equal(element.log.getCall(1).args[1], "data received");
+                assert.deepEqual(element.log.getCall(1).args[2], { cached: false });
                 // Should send a data-update event
                 assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
                 assert.deepEqual(element._sendEvent.getCall(0).args[1], largeRssJson.slice(0, 15));
@@ -236,8 +236,8 @@
                 assert.isTrue(riseElement._setUptimeError.calledWith(true));
 
                 // Should log the error data
-                assert.equal(element.log.getCall(3).args[1], "rss-data-error");
-                assert.deepEqual(element.log.getCall(3).args[2], { error: invalidRssJson.Error });
+                assert.equal(element.log.getCall(1).args[1], "data received");
+                assert.deepEqual(element.log.getCall(1).args[2], { cached: false });
                 // Should send a data-error event
                 assert.equal(element._sendEvent.getCall(0).args[0], "data-error");
                 assert.deepEqual(element._sendEvent.getCall(0).args[1], { error: invalidRssJson.Error });
@@ -252,6 +252,8 @@
 
             sandbox.stub(cacheMixin, "getCache").rejects();
             sandbox.stub(fetchMixin, "_isOffline").resolves(false);
+            element.fetchConfig.count = 0;
+
             window.fetch.rejects({ message: errorMessage });
 
             element.feedUrl = sampleFeedUrl;
@@ -263,8 +265,8 @@
                 assert.isTrue(riseElement._setUptimeError.calledWith(true));
 
                 // Should log the request error data
-                assert.equal(element.log.getCall(2).args[1], "rss-request-error");
-                assert.deepEqual(element.log.getCall(2).args[2], { error: errorMessage });
+                assert.equal(element.log.getCall(1).args[1], "request error");
+                assert.deepEqual(element.log.getCall(1).args[2], { error: errorMessage });
                 // Should send a request-error event
                 assert.equal(element._sendEvent.getCall(0).args[0], "request-error");
                 assert.deepEqual(element._sendEvent.getCall(0).args[1], { error: errorMessage });
@@ -289,7 +291,7 @@
 
               setTimeout(() => {
                 assert.isFalse(riseElement._setUptimeError.called);
-                assert.isFalse(element.log.calledThrice); // start | rss-start
+                assert.isTrue(element.log.calledOnce);
                 assert.isFalse(element._handleResponse.called);
                 assert.isFalse(element._sendEvent.called);
 

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -252,7 +252,7 @@
 
             sandbox.stub(cacheMixin, "getCache").rejects();
             sandbox.stub(fetchMixin, "_isOffline").resolves(false);
-            sandbox.stub(fetchMixin, "_shouldRetryWithErrorHandling").returns(true);
+            sandbox.stub(fetchMixin, "_isMaxRetryAttempt").returns(true);
 
             window.fetch.rejects({ message: errorMessage });
 
@@ -282,7 +282,7 @@
             sandbox.stub(element, "_handleResponse");
             sandbox.stub(cacheMixin, "getCache").rejects();
             sandbox.stub(fetchMixin, "_isOffline").resolves(true);
-            sandbox.stub(fetchMixin, "_shouldRetryWithErrorHandling").returns(true);
+            sandbox.stub(fetchMixin, "_isMaxRetryAttempt").returns(true);
             window.fetch.rejects({ message: errorMessage });
 
             element.feedUrl = sampleFeedUrl;

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -58,7 +58,6 @@
           cacheMixin = element.__proto__.__proto__.__proto__;
           loggerMixin = element.__proto__.__proto__.__proto__.__proto__.__proto__;
 
-          sandbox.stub(cacheMixin, "initCache");
           sandbox.stub(loggerMixin, "initLogger");
           sandbox.stub(loggerMixin, "log");
           sandbox.stub(window, "fetch");
@@ -262,6 +261,35 @@
                 done();
               }, 20);
             });
+          });
+
+          test("should use cached data when it fails to connect to feed-parser", done => {
+            let errorMessage = "Failed to connect to feed-parser";
+
+            window.fetch.rejects({ message: errorMessage });
+            sandbox.stub(cacheMixin, "getCache").callsFake(function (url, ignoreExpiration) {
+              if (ignoreExpiration) {
+                return Promise.resolve(new Response(JSON.stringify(validRssJson)));
+              } else {
+                return Promise.reject();
+              }
+            });
+
+            element.feedUrl = sampleFeedUrl;
+
+            setTimeout(() => {
+              assert.isTrue(window.fetch.called);
+              assert.equal(window.fetch.args[0][0], sampleServerUrl + sampleFeedUrl);
+
+              // Should log the received data
+              assert.equal(element.log.getCall(2).args[1], "rss-data-update");
+              assert.deepEqual(element.log.getCall(2).args[2], {});
+              // Should send a data-update event
+              assert.equal(element._sendRssEvent.getCall(0).args[0], "data-update");
+              assert.deepEqual(element._sendRssEvent.getCall(0).args[1], validRssJson);
+
+              done();
+            }, 30);
           });
         });
       });

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -252,7 +252,7 @@
 
             sandbox.stub(cacheMixin, "getCache").rejects();
             sandbox.stub(fetchMixin, "_isOffline").resolves(false);
-            element.fetchConfig.count = 0;
+            sandbox.stub(fetchMixin, "_shouldRetryWithErrorHandling").returns(true);
 
             window.fetch.rejects({ message: errorMessage });
 
@@ -282,6 +282,7 @@
             sandbox.stub(element, "_handleResponse");
             sandbox.stub(cacheMixin, "getCache").rejects();
             sandbox.stub(fetchMixin, "_isOffline").resolves(true);
+            sandbox.stub(fetchMixin, "_shouldRetryWithErrorHandling").returns(true);
             window.fetch.rejects({ message: errorMessage });
 
             element.feedUrl = sampleFeedUrl;
@@ -291,7 +292,7 @@
 
               setTimeout(() => {
                 assert.isFalse(riseElement._setUptimeError.called);
-                assert.isTrue(element.log.calledOnce);
+                assert.isTrue(element.log.calledTwice);
                 assert.isFalse(element._handleResponse.called);
                 assert.isFalse(element._sendEvent.called);
 

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -235,9 +235,12 @@
               setTimeout(() => {
                 assert.isTrue(riseElement._setUptimeError.calledWith(true));
 
-                // Should log the error data
+                // Should log the received data
                 assert.equal(element.log.getCall(1).args[1], "data received");
                 assert.deepEqual(element.log.getCall(1).args[2], { cached: false });
+                // Should log the error data
+                assert.equal(element.log.getCall(2).args[1], "data error");
+                assert.deepEqual(element.log.getCall(2).args[2], { error: invalidRssJson.Error });
                 // Should send a data-error event
                 assert.equal(element._sendEvent.getCall(0).args[0], "data-error");
                 assert.deepEqual(element._sendEvent.getCall(0).args[1], { error: invalidRssJson.Error });

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -235,10 +235,10 @@
               setTimeout(() => {
                 assert.isTrue(riseElement._setUptimeError.calledWith(true));
 
-                // Should log the received data
+                // Should log the error data
                 assert.equal(element.log.getCall(3).args[1], "rss-data-error");
                 assert.deepEqual(element.log.getCall(3).args[2], { error: invalidRssJson.Error });
-                // Should send a data-update event
+                // Should send a data-error event
                 assert.equal(element._sendEvent.getCall(0).args[0], "data-error");
                 assert.deepEqual(element._sendEvent.getCall(0).args[1], { error: invalidRssJson.Error });
 
@@ -251,6 +251,7 @@
             let errorMessage = "Failed to connect to feed-parser";
 
             sandbox.stub(cacheMixin, "getCache").rejects();
+            sandbox.stub(fetchMixin, "_isOffline").resolves(false);
             window.fetch.rejects({ message: errorMessage });
 
             element.feedUrl = sampleFeedUrl;
@@ -273,35 +274,28 @@
             });
           });
 
-          test("should use cached data when it fails to connect to feed-parser", done => {
+          test("should handle failure to connect to feed-parser and not log if offline", done => {
             let errorMessage = "Failed to connect to feed-parser";
 
+            sandbox.stub(element, "_handleResponse");
+            sandbox.stub(cacheMixin, "getCache").rejects();
+            sandbox.stub(fetchMixin, "_isOffline").resolves(true);
             window.fetch.rejects({ message: errorMessage });
-            sandbox.stub(cacheMixin, "getCache").callsFake(function (url, ignoreExpiration) {
-              if (ignoreExpiration) {
-                return Promise.resolve(new Response(JSON.stringify(validRssJson)));
-              } else {
-                return Promise.reject();
-              }
-            });
 
             element.feedUrl = sampleFeedUrl;
 
             setTimeout(() => {
-              assert.isTrue(riseElement._setUptimeError.calledWith(false));
-
               assert.isTrue(window.fetch.called);
-              assert.equal(window.fetch.args[0][0], sampleServerUrl + sampleFeedUrl);
 
-              // Should log the received data
-              assert.equal(element.log.getCall(2).args[1], "rss-data-update");
-              assert.deepEqual(element.log.getCall(2).args[2], {});
-              // Should send a data-update event
-              assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
-              assert.deepEqual(element._sendEvent.getCall(0).args[1], validRssJson);
+              setTimeout(() => {
+                assert.isFalse(riseElement._setUptimeError.called);
+                assert.isFalse(element.log.calledThrice); // start | rss-start
+                assert.isFalse(element._handleResponse.called);
+                assert.isFalse(element._sendEvent.called);
 
-              done();
-            }, 30);
+                done();
+              }, 20);
+            });
           });
         });
       });


### PR DESCRIPTION
## Description
This adds support for offline play, using cached data. In case a fetch request fails and we detect the client is offline, we will try to deliver the latest cached response (ignoring expiration date).

To detect if the machine is offline we rely on https://widgets.risevision.com, which should be available in the users machine and has appropriate CORS settings.

## Motivation and Context
Rise Image and Rise Video handle cached content using Player provided features. These are not available, as far as I understand, for content not hosted on GCS. Rise RSS needs to support offline play.

## How Has This Been Tested?
Testing has been performed using Chrome Dev Tools to simulate offline scenarios, while using the Demo page for `rise-data-rss`. More specifically, a breakpoint was set before performing the first `fetch` call and only then the Offline mode was set (otherwise Chrome does not load the Demo page, which is served through a local web server).

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No items were skipped. Commit hash in reference to `rise-common-component` will be updated with correct tag before merging to master (for some reason using branch name was not good enough to get latest changes when building on CCI)

@santiagonoguez @stulees please review
