### PR TITLE
Fix attribute names

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The below illustrates simple usage of the component.
 ```
   <rise-data-rss
       id="rise-data-rss-01" label="Test Feed"
-      feed-url="https://www.feedforall.com/sample.xml"
-      max-items="15">
+      feedurl="https://www.feedforall.com/sample.xml"
+      maxitems="15">
   </rise-data-rss>
 ```
 
@@ -26,8 +26,8 @@ This component receives the following list of attributes:
 
 - **id**: ( string ): Unique HTMLElement id.
 - **label**: (string): Assigns the label to use for the instance of the component in Template Editor.
-- **feed-url**: (string / required): The url to the RSS feed to be used for this instance.
-- **max-items**: (number / optional): The maximum number of elements to retrieve from the RSS feed. If the attribute is empty or zero, all the elements, up to the maximum, are retrieved. Defaults to 25, which is also the maximum.
+- **feedurl**: (string / required): The url to the RSS feed to be used for this instance.
+- **maxitems**: (number / optional): The maximum number of elements to retrieve from the RSS feed. If the attribute is empty or zero, all the elements, up to the maximum, are retrieved. Defaults to 25, which is also the maximum.
 - **non-editable**: ( empty / optional ): If present, it indicates this component is not available for customization in the Template Editor.
 
 The feed is refreshed every 5 minutes. The refresh rate is not modifiable.

--- a/demo/src/rise-data-rss.html
+++ b/demo/src/rise-data-rss.html
@@ -54,8 +54,8 @@
 <body>
   <rise-data-rss
       id="rise-data-rss-01" label="Test Feed"
-      feed-url="https://www.feedforall.com/sample.xml"
-      max-items="15">
+      feedurl="https://www.feedforall.com/sample.xml"
+      maxitems="15">
   </rise-data-rss>
 
   <div id="rssFeed" class="feedContainer">

--- a/e2e/rise-data-rss.html
+++ b/e2e/rise-data-rss.html
@@ -66,8 +66,8 @@
   <body>
     <rise-data-rss
         id="rise-data-rss-01" label="Test Feed"
-        feed-url="https://www.feedforall.com/sample.xml"
-        max-items="25">
+        feedurl="https://www.feedforall.com/sample.xml"
+        maxitems="25">
     </rise-data-rss>
 
     <div id="rssFeed" class="feedContainer"></div>

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -15,14 +15,14 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
       /**
        * The url of the feed that will be requested through feed-parser.
        */
-      feedUrl: {
+      feedurl: {
         type: String,
         observer: "_feedUrlChanged"
       },
       /**
        * The maximum number of items to return from the feed. The maximum allowed is 25.
        */
-      maxItems: {
+      maxitems: {
         type: Number,
         value: 25
       },
@@ -77,14 +77,14 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
     if (this._initialStart) {
       this._initialStart = false;
 
-      if (this.feedUrl) {
+      if (this.feedurl) {
         this._loadFeedData();
       }
     }
   }
 
   _getUrl() {
-    return rssConfig.feedParserURL + "/" + this.feedUrl;
+    return rssConfig.feedParserURL + "/" + this.feedurl;
   }
 
   _feedUrlChanged() {
@@ -92,7 +92,7 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
   }
 
   _loadFeedData() {
-    if (!this._initialStart && this.feedUrl) {
+    if (!this._initialStart && this.feedurl) {
       super.fetch(this._getUrl(), {
         headers: { "X-Requested-With": "rise-data-rss" }
       });
@@ -107,7 +107,7 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
   _processRssData(data) {
     if (!data.Error) {
       if (!isEqual(this.feedData, data)) {
-        this._setFeedData(data.slice(0, this.maxItems));
+        this._setFeedData(data.slice(0, this.maxitems));
 
         this.log( "info", "data provided" );
 

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -17,14 +17,15 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
        */
       feedurl: {
         type: String,
-        observer: "_feedUrlChanged"
+        observer: "_feedurlChanged"
       },
       /**
        * The maximum number of items to return from the feed. The maximum allowed is 25.
        */
       maxitems: {
         type: Number,
-        value: 25
+        value: 25,
+        observer: "_maxitemsChanged"
       },
       /**
        * The latest successful response from the feed.
@@ -87,7 +88,11 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
     return rssConfig.feedParserURL + "/" + this.feedurl;
   }
 
-  _feedUrlChanged() {
+  _feedurlChanged() {
+    this._loadFeedData();
+  }
+
+  _maxitemsChanged() {
     this._loadFeedData();
   }
 

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -71,12 +71,12 @@
         });
 
         suite("properties", () => {
-          test("should not set feedUrl", () => {
-            assert.notOk(element.feedUrl);
+          test("should not set feedurl", () => {
+            assert.notOk(element.feedurl);
           });
 
-          test("should set maxItems", () => {
-            assert.equal(element.maxItems, 25);
+          test("should set maxitems", () => {
+            assert.equal(element.maxitems, 25);
           });
         });
 
@@ -123,7 +123,7 @@
           test("should request data only after start has been called", done => {
             sandbox.stub(fetchMixin, "fetch");
 
-            element.feedUrl = "sampleFeedUrl";
+            element.feedurl = "sampleFeedUrl";
 
             setTimeout(() => {
               assert.isFalse(fetchMixin.fetch.called);
@@ -150,7 +150,7 @@
           test("should handle a valid response from cache", done => {
             sandbox.stub(cacheMixin, "getCache").resolves(new Response(JSON.stringify(validRssJson)));
 
-            element.feedUrl = sampleFeedUrl;
+            element.feedurl = sampleFeedUrl;
 
             setTimeout(() => {
               assert.isTrue(riseElement._setUptimeError.calledWith(false));
@@ -171,7 +171,7 @@
             sandbox.stub(cacheMixin, "getCache").rejects();
             window.fetch.resolves(new Response(JSON.stringify(validRssJson)));
 
-            element.feedUrl = sampleFeedUrl;
+            element.feedurl = sampleFeedUrl;
 
             setTimeout(() => {
               assert.isTrue(riseElement._setUptimeError.calledWith(false));
@@ -202,8 +202,8 @@
             sandbox.stub(cacheMixin, "getCache").rejects();
             window.fetch.resolves(new Response(JSON.stringify(largeRssJson)));
 
-            element.maxItems = 15;
-            element.feedUrl = sampleFeedUrl;
+            element.maxitems = 15;
+            element.feedurl = sampleFeedUrl;
 
             setTimeout(() => {
               assert.isTrue(window.fetch.called);
@@ -228,7 +228,7 @@
             sandbox.stub(cacheMixin, "getCache").rejects();
             window.fetch.resolves(new Response(JSON.stringify(invalidRssJson)));
 
-            element.feedUrl = sampleFeedUrl;
+            element.feedurl = sampleFeedUrl;
 
             setTimeout(() => {
               assert.isTrue(window.fetch.called);
@@ -261,7 +261,7 @@
 
             window.fetch.rejects({ message: errorMessage });
 
-            element.feedUrl = sampleFeedUrl;
+            element.feedurl = sampleFeedUrl;
 
             setTimeout(() => {
               assert.isTrue(window.fetch.called);
@@ -290,7 +290,7 @@
             sandbox.stub(fetchMixin, "_isMaxRetryAttempt").returns(true);
             window.fetch.rejects({ message: errorMessage });
 
-            element.feedUrl = sampleFeedUrl;
+            element.feedurl = sampleFeedUrl;
 
             setTimeout(() => {
               assert.isTrue(window.fetch.called);


### PR DESCRIPTION
## Description
Code in `common-template` does not properly handle the case of attributes with dashes in its name. Until (if) we improve that, we need to avoid camel case/dashes (`feedUrl` turns into `feed-url`). 

## Motivation and Context
Feed URL was not being properly updated

## How Has This Been Tested?
It can be tested here: https://apps-stage-8.risevision.com/templates/edit/5fefe507-9ccf-4c22-bde4-a3fe6e513327/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@santiagonoguez @stulees please review
