### PR TITLE
Fix _processData so it considers chances in item count

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
       - run: |
-          VERSION=$(cat version-string/version)
+          VERSION=$(grep version package.json | grep -o '[0-9.]*')
           sed -i "s/__VERSION__/$VERSION/;" src/rise-data-rss-version.js
       - run: npm run build
       - persist_to_workspace:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Rise Data Rss",
   "scripts": {
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -111,8 +111,10 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
 
   _processRssData(data) {
     if (!data.Error) {
-      if (!isEqual(this.feedData, data)) {
-        this._setFeedData(data.slice(0, this.maxitems));
+      let slicedData = data.slice(0, this.maxitems);
+
+      if (!isEqual(this.feedData, slicedData)) {
+        this._setFeedData(slicedData);
 
         this.log( "info", "data provided" );
 

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -16,16 +16,14 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
        * The url of the feed that will be requested through feed-parser.
        */
       feedurl: {
-        type: String,
-        observer: "_feedurlChanged"
+        type: String
       },
       /**
        * The maximum number of items to return from the feed. The maximum allowed is 25.
        */
       maxitems: {
         type: Number,
-        value: 25,
-        observer: "_maxitemsChanged"
+        value: 25
       },
       /**
        * The latest successful response from the feed.
@@ -35,6 +33,14 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
         readOnly: true
       }
     };
+  }
+
+  // Each item of observers array is a method name followed by
+  // a comma-separated list of one or more dependencies.
+  static get observers() {
+    return [
+      "_reset(feedurl, maxitems)"
+    ]
   }
 
   // Event name constants
@@ -88,11 +94,7 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
     return rssConfig.feedParserURL + "/" + this.feedurl;
   }
 
-  _feedurlChanged() {
-    this._loadFeedData();
-  }
-
-  _maxitemsChanged() {
+  _reset() {
     this._loadFeedData();
   }
 

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -138,6 +138,48 @@
           });
         });
 
+        suite("_processRssData", () => {
+          setup(() => {
+            sandbox.stub(element, "_loadFeedData");
+            sandbox.stub(element, "_sendRssEvent");
+          });
+
+          test("should set feedData", () => {
+            element._processRssData([{ title: "Title 1" }]);
+
+            assert.equal(element.feedData.length, 1);
+            assert.isTrue(element._sendRssEvent.calledOnce);
+          });
+
+          test("should set feedData again if data changed", () => {
+            element._processRssData([{ title: "Title 1" }]);
+            element._processRssData([{ title: "Title 2" }]);
+
+            assert.equal(element.feedData.length, 1);
+            assert.isTrue(element._sendRssEvent.calledTwice);
+          });
+
+          test("should set feedData again if max items has changed", () => {
+            var data = [{ title: "Title 1" }, { title: "Title 2" }, { title: "Title 3" }];
+
+            element.maxitems = 3;
+            element._processRssData(data);
+            element.maxitems = 2;
+            element._processRssData(data);
+
+            assert.equal(element.feedData.length, 2);
+            assert.isTrue(element._sendRssEvent.calledTwice);
+          });
+
+          test("should not set feedData again if data has not changed", () => {
+            element._processRssData([{ title: "Title 1" }]);
+            element._processRssData([{ title: "Title 1" }]);
+
+            assert.equal(element.feedData.length, 1);
+            assert.isTrue(element._sendRssEvent.calledOnce);
+          });
+        });
+
         suite("_loadFeedData", () => {
           let response;
 


### PR DESCRIPTION
## Description
This fixes the way comparison for old data is done, to also take into account length of data and `maxitems`.

This also switches to using a single observer (`_reset`) and uses the same `VERSION` logic as `rise-image`.

## Motivation and Context
When comparing previously received data with new data changes in `maxitems` where only applied after the comparison. This caused that if the feed returned 10 items (as the sample https://www.feedforall.com/sample.xml) and we changed the `maxitems` attributes from 10 to 5 (or less) the component would not update the content. 

## How Has This Been Tested?
Can be tested here: https://apps-stage-8.risevision.com/templates/edit/9327a72c-9f82-4132-b578-075510dd46af/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

I changed the feed to Hacker News' https://hnrss.org/frontpage, since it returns 20 items. You can test by changing the number of items, which will cause the feed to reload (you can wait a few seconds before making the change to make sure it returns to the first feed item). If you switch from 20 to 25 you will not see a reload, since the data would not have changed.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@santiagonoguez @stulees please review
