### PR TITLE
Provide data to users of the component if an error ocurred previously, even if data has not changed since the last successful fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Rise Data Rss",
   "scripts": {
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -61,6 +61,7 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
 
     this._setVersion(version);
     this._initialStart = true;
+    this._latestFailed = false;
   }
 
   ready() {
@@ -115,7 +116,8 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
     if (!data.Error) {
       let slicedData = data.slice(0, this.maxitems);
 
-      if (!isEqual(this.feedData, slicedData)) {
+      if (!isEqual(this.feedData, slicedData) || this._latestFailed) {
+        this._latestFailed = false;
         this._setFeedData(slicedData);
 
         this.log( "info", "data provided" );
@@ -126,6 +128,7 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
     else {
       let error = data.Error;
 
+      this._latestFailed = true;
       this.log( "error", "data error", { error });
 
       this._sendRssEvent(RiseDataRss.EVENT_DATA_ERROR, { error });

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -178,6 +178,24 @@
             assert.equal(element.feedData.length, 1);
             assert.isTrue(element._sendRssEvent.calledOnce);
           });
+
+          test("should set feedData again if an error happened before the second call, even if data has not changed", () => {
+            element._processRssData([{ title: "Title 1" }]);
+            element._latestFailed = true;
+            element._processRssData([{ title: "Title 1" }]);
+
+            assert.equal(element.feedData.length, 1);
+            assert.isTrue(element._sendRssEvent.calledTwice);
+            assert.isFalse(element._latestFailed);
+          });
+
+          test("should set _latestFailed to true if an error ocurred", () => {
+            element._processRssData({ Error: "An error ocurred" });
+
+            assert.isTrue(!element.feedData);
+            assert.isTrue(element._sendRssEvent.calledOnce);
+            assert.isTrue(element._latestFailed);
+          });
         });
 
         suite("_loadFeedData", () => {


### PR DESCRIPTION
## Description
If the latest generated event was an error, the next successful data retrieval should generate a data event.

## Motivation and Context
During Preview, if the user enters a valid url (which returns valid data) then an invalid one (which causes an error) and finally goes back to the previous valid url, the component will not receive the valid data since it will not have changed since the latest successful retrieval.

Taking into account possible errors fixes this situation, since it provides data to users after a failure and the presentation can be updated properly.

## How Has This Been Tested?
This has been tested using Charles and pointing the component files to my local drive.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@santiagonoguez @stulees please review
