### PR TITLE
Set duration for cached elements of 4:30 minutes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Rise Data Rss",
   "scripts": {
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -75,7 +75,7 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
 
     super.initCache({
       name: this.tagName.toLowerCase(),
-      duration: 1000 * 60 * 5,
+      duration: 1000 * 60 * 4.5, // Timers are not precise; we want fetch to retrieve fresh data every five minutes
       expiry: -1
     });    
   }

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -75,6 +75,7 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
 
     super.initCache({
       name: this.tagName.toLowerCase(),
+      duration: 1000 * 60 * 5,
       expiry: -1
     });    
   }


### PR DESCRIPTION
## Description
RSS component needs to update its data every five minutes. If cache duration is not set correctly, fresh data will not be retrieved as often as needed.

## Motivation and Context
Cache was not properly initialized, which meant data was not refreshed every five minutes but instead every two hours. Since fetch's refresh interval is set to 5min, and timers are not really precise, cache duration is set to 4:30min to account for inaccurate timers.

## How Has This Been Tested?
It was tested using Charles to use my local build of the component.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@santiagonoguez @stulees please review