### PR TITLE
Standardize provided feed fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The **data-update** event provides an object with the following fields:
 - **link**: Link to the feed's originating post.
 - **imageUrl**: The image associated to the post. The component looks for images in several places and provides the first valid image it finds, prioritizing what it finds in determined fields.
 - **author**: Author of the post.
-- **pubDate**: Publication date
+- **pubDate**: Publication date.
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ The component listens for the following events:
 
 - **start**: This event will make an initial fetch for the RSS feed and then periodically fetch the RSS feed (refresh will be disabled in Preview). It can be dispatched to the component when the _configured_ event has been fired.
 
+### Provided data
+
+The **data-update** event provides an object with the following fields:
+
+- **title**: Title of the feed.
+- **description**: Description of the feed. Any `img` tag embedded in the feed will be removed before generating the event.
+- **link**: Link to the feed's originating post.
+- **imageUrl**: The image associated to the post. The component looks for images in several places and provides the first valid image it finds, prioritizing what it finds in determined fields.
+- **author**: Author of the post.
+- **pubDate**: Publication date
+
 ### Logging
 
 The component logs the following events to BQ:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -382,10 +382,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Rise Data Rss",
   "scripts": {
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "eslint": "^5.16.0",
+    "eslint-utils": ">=1.4.1",
     "@polymer/test-fixture": "^4.0.2",
     "chai": "^4.2.0",
     "mocha": "^5.2.0",

--- a/src/feed-formatter.js
+++ b/src/feed-formatter.js
@@ -1,0 +1,83 @@
+//const URL_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&\/\/=]*)/;
+const URL_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
+
+export default class FeedFormatter {
+  formatFeed (feed) {
+    let formatted = {};
+
+    formatted.title = this._getTitle(feed);
+    formatted.description = this._getDescription(feed);
+    formatted.link = this._getLink(feed);
+    formatted.imageUrl = this._getImageUrl(feed);
+    formatted.author = this._getAuthor(feed);
+    formatted.pubDate = this._getPubDate(feed);
+
+    return formatted;
+  }
+
+  _getTitle (feed) {
+    return feed.title;
+  }
+
+  _getDescription (feed) {
+    if (feed["rss:description"] && feed["rss:description"]["#"]) {
+      return feed["rss:description"]["#"];
+    } else if (feed.summary) {
+      return feed.summary;
+    } else {
+      return feed.description;
+    }
+  }
+
+  _getLink (feed) {
+    return feed.link || feed.permalink;
+  }
+
+  _getImageUrl (feed) {
+    let foundImages = [];
+
+    if (feed["content:encoded"] && feed["content:encoded"]["#"]) {
+      let rgx = new RegExp("src='(" + URL_REGEX.source + ")'");
+      let res = feed["content:encoded"]["#"].match(rgx);
+
+      if (res.length > 1 && res[1]) {
+        foundImages.push(res[1]);
+      }
+    }
+
+    if (feed["rss:image"] && feed["rss:image"]["#"]) {
+      foundImages.push(feed["rss:image"]["#"]);
+    }
+
+    if (feed["media:thumbnail"] && feed["media:thumbnail"]["@"] && feed["media:thumbnail"]["@"].url) {
+      foundImages.push(feed["media:thumbnail"]["@"].url);
+    }
+
+    if (feed.enclosures && feed.enclosures.length > 0 && feed.enclosures[0].url) {
+      foundImages.push(feed.enclosures[0].url);
+    }
+
+    if (feed.image && feed.image.url) {
+      foundImages.push(feed.image.url);
+    }
+
+    return foundImages.find(this._isValidImage);
+  }
+
+  _getAuthor (feed) {
+    return feed.author;
+  }
+
+  _getPubDate (feed) {
+    return feed.pubdate || feed.pubDate;
+  }
+
+  _isValidImage (imageUrl) {
+    let validFormats = [ "bmp", "jpeg", "jpg", "png" ];
+    let url = imageUrl.toLowerCase();
+
+    return !!validFormats.find( ext => {
+      return url.endsWith("." + ext) || url.indexOf("." + ext + "?") >= 0;
+    });
+  }
+}

--- a/src/feed-formatter.js
+++ b/src/feed-formatter.js
@@ -1,5 +1,6 @@
-//const URL_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&\/\/=]*)/;
 const URL_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
+const PREFERRED_FORMATS = [ "jpeg", "jpg", "png" ];
+const ALT_FORMATS = [ "bmp", "gif" ];
 
 export default class FeedFormatter {
   formatFeed (feed) {
@@ -61,7 +62,7 @@ export default class FeedFormatter {
       foundImages.push(feed.image.url);
     }
 
-    return foundImages.find(this._isValidImage);
+    return this._getBestImage(foundImages);
   }
 
   _getAuthor (feed) {
@@ -72,12 +73,23 @@ export default class FeedFormatter {
     return feed.pubdate || feed.pubDate;
   }
 
-  _isValidImage (imageUrl) {
-    let validFormats = [ "bmp", "jpeg", "jpg", "png" ];
+  _isValidImage (imageUrl, validFormats) {
     let url = imageUrl.toLowerCase();
 
     return !!validFormats.find( ext => {
       return url.endsWith("." + ext) || url.indexOf("." + ext + "?") >= 0;
     });
+  }
+
+  _getBestImage (foundImages) {
+    return foundImages.find(this._isPreferredFormat.bind(this)) || foundImages.find(this._isAltFormat.bind(this));
+  }
+
+  _isPreferredFormat (imageUrl) {
+    return this._isValidImage(imageUrl, PREFERRED_FORMATS);
+  }
+
+  _isAltFormat (imageUrl) {
+    return this._isValidImage(imageUrl, ALT_FORMATS);
   }
 }

--- a/src/feed-formatter.js
+++ b/src/feed-formatter.js
@@ -32,7 +32,6 @@ export default class FeedFormatter {
 
     if (description) {
       description = this._removeElements(description, "img");
-      description = this._removeElements(description, "a");
     }
 
     return description;

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -4,6 +4,7 @@ import { FetchMixin } from "rise-common-component/src/fetch-mixin.js";
 
 import { rssConfig } from "./rise-data-rss-config.js";
 import { version } from "./rise-data-rss-version.js";
+import FeedFormatter from "./feed-formatter.js";
 import isEqual from "lodash-es/isEqual";
 
 const fetchBase = CacheMixin( RiseElement );
@@ -62,6 +63,7 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
     this._setVersion(version);
     this._initialStart = true;
     this._latestFailed = false;
+    this._feedFormatter = new FeedFormatter();
   }
 
   ready() {
@@ -123,7 +125,9 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
 
         this.log( "info", "data provided" );
 
-        this._sendRssEvent(RiseDataRss.EVENT_DATA_UPDATE, this.feedData);
+        this._sendRssEvent(RiseDataRss.EVENT_DATA_UPDATE, this.feedData.map( item => {
+          return this._feedFormatter.formatFeed(item);
+        }));
       }
     }
     else {

--- a/test/feed-formatter-test.html
+++ b/test/feed-formatter-test.html
@@ -1,0 +1,221 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>feed-formatter test</title>
+
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script src="../node_modules/chai/chai.js"></script>
+    <script src="../node_modules/wct-mocha/wct-mocha.js"></script>
+    <script src="../node_modules/sinon/pkg/sinon.js"></script>
+  </head>
+  <body>
+    <script type="module">
+      import FeedFormatter from "../src/feed-formatter.js";
+
+      suite("feed-formatter", () => {
+        let sandbox = sinon.createSandbox();
+        let formatter = new FeedFormatter();
+
+        setup(() => {
+          
+        });
+
+        teardown(()=>{
+          sandbox.restore();
+        });
+
+        suite("basics", () => {
+          test("should handle an empty feed", () => {
+            assert.isTrue(formatter.formatFeed({}) != null);
+          });
+        });
+
+        suite("title", () => {
+          test("should return the correct title", () => {
+            assert.equal(formatter.formatFeed({}).title, null);
+            assert.equal(formatter.formatFeed(nprSample).title, "In Book, Former Defense Chief Mattis Sideswipes President Trump's Leadership Skills");
+            assert.equal(formatter.formatFeed(wiredSample).title, "Fitbit Premium, Versa 2, Aria Air: Pricing, Specs, Details");
+            assert.equal(formatter.formatFeed(espnSample).title, "Kobe: 'Nothin but love' for Shaq after drama");
+          });
+        });
+
+        suite("description", () => {
+          test("should return the correct description", () => {
+            assert.equal(formatter.formatFeed({}).description, null);
+            assert.equal(formatter.formatFeed(nprSample).description, "In the general's upcoming leadership book,<em> Call Sign Chaos,</em> the Obama administration catches the most flak. Mattis barely mentions President Trump but implies criticism of the sitting president.");
+            assert.equal(formatter.formatFeed(wiredSample).description, "The company’s new offerings include two fitness-tracking products, a subscription service for personalized health advice, and lots and lots of partnerships.");
+            assert.equal(formatter.formatFeed(espnSample).description, "Kobe Bryant and Shaquille O'Neal, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym.");
+          });
+        });
+
+        suite("link", () => {
+          test("should return the correct link", () => {
+            assert.equal(formatter.formatFeed({}).link, null);
+            assert.equal(formatter.formatFeed(nprSample).link, "https://www.npr.org/2019/08/28/755018189/in-book-former-defense-chief-mattis-side-swipes-president-trump-s-leadership-ski?utm_medium=RSS&utm_campaign=news");
+            assert.equal(formatter.formatFeed(wiredSample).link, "https://www.wired.com/story/fitbit-versa-2-aria-air-smart-scale-fitbit-premium");
+            assert.equal(formatter.formatFeed(espnSample).link, "http://www.espn.com/nba/story/_/id/27485035/kobe-nothin-love-shaq-drama");
+          });
+        });
+
+        suite("imageUrl", () => {
+          test("should return the correct imageUrl", () => {
+            assert.equal(formatter.formatFeed({}).imageUrl, null);
+            assert.equal(formatter.formatFeed(nprSample).imageUrl, "https://media.npr.org/assets/img/2019/08/28/gettyimages-1074493698_wide-d77a974046aaf94c8bd37c8083750e56ee67606a.jpg?s=600");
+            assert.equal(formatter.formatFeed(wiredSample).imageUrl, "https://media.wired.com/photos/5d65a6d443e62000086148e5/master/pass/Gear-Fitbit_Versa_2-Lead.jpg");
+            assert.equal(formatter.formatFeed(espnSample).imageUrl, "https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.jpg");
+          });
+        });
+
+        suite("author", () => {
+          test("should return the correct author", () => {
+            assert.equal(formatter.formatFeed({}).author, null);
+            assert.equal(formatter.formatFeed(nprSample).author, "David Welna");
+            assert.equal(formatter.formatFeed(wiredSample).author, "Adrienne So");
+            assert.equal(formatter.formatFeed(espnSample).author, null);
+          });
+        });
+
+        suite("pubDate", () => {
+          test("should return the correct pubDate", () => {
+            assert.equal(formatter.formatFeed({}).pubDate, null);
+            assert.equal(formatter.formatFeed(nprSample).pubDate, "2019-08-28T17:52:00.000Z");
+            assert.equal(formatter.formatFeed(wiredSample).pubDate, "2019-08-28T13:00:00.000Z");
+            assert.equal(formatter.formatFeed(espnSample).pubDate, "2019-08-28T19:27:14.000Z");
+          });
+        });
+
+        suite("_isValidImage", () => {
+          test("should return true for valid images", () => {
+            assert.isTrue(formatter._isValidImage("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.jpg"));
+            assert.isTrue(formatter._isValidImage("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.png"));
+            assert.isTrue(formatter._isValidImage("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.jpg?test=1"));
+          });
+
+          test("should return false for non valid images", () => {
+            assert.isFalse(formatter._isValidImage("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.gif"));
+            assert.isFalse(formatter._isValidImage("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.pdf"));
+            assert.isFalse(formatter._isValidImage("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.gif?test=1"));
+          });
+        });
+      });
+
+      let nprSample = {
+        "title": "In Book, Former Defense Chief Mattis Sideswipes President Trump's Leadership Skills",
+        "description": "<img src='https://media.npr.org/assets/img/2019/08/28/gettyimages-1074493698_wide-d77a974046aaf94c8bd37c8083750e56ee67606a.jpg?s=600' alt='James Mattis, then U.S. secretary of defense, leaves a news conference following a meeting about U.S.-China diplomacy and security at the State Department in Washington, D.C., in June 2017. Mattis' new book, Call Sign Chaos, implies criticism of President Trump without taking direct shots at him.'/><p>In the general's upcoming leadership book,<em> Call Sign Chaos,</em> the Obama administration catches the most flak. Mattis barely mentions President Trump but implies criticism of the sitting president.</p><p>(Image credit: Bloomberg via Getty Images)</p><img src='https://media.npr.org/include/images/tracking/npr-rss-pixel.png?story=755018189' />",
+        "summary": "In the general's upcoming leadership book,<em> Call Sign Chaos,</em> the Obama administration catches the most flak. Mattis barely mentions President Trump but implies criticism of the sitting president.",
+        "pubdate": "2019-08-28T17:52:00.000Z",
+        "pubDate": "2019-08-28T17:52:00.000Z",
+        "link": "https://www.npr.org/2019/08/28/755018189/in-book-former-defense-chief-mattis-side-swipes-president-trump-s-leadership-ski?utm_medium=RSS&utm_campaign=news",
+        "author": "David Welna",
+        "image": {},
+        "enclosures": [],
+        "rss:title": {
+          "@": {},
+          "#": "In Book, Former Defense Chief Mattis Sideswipes President Trump's Leadership Skills"
+        },
+        "rss:description": {
+          "@": {},
+          "#": "In the general's upcoming leadership book,<em> Call Sign Chaos,</em> the Obama administration catches the most flak. Mattis barely mentions President Trump but implies criticism of the sitting president."
+        },
+        "rss:pubdate": {
+          "@": {},
+          "#": "Wed, 28 Aug 2019 13:52:00 -0400"
+        },
+        "rss:link": {
+          "@": {},
+          "#": "https://www.npr.org/2019/08/28/755018189/in-book-former-defense-chief-mattis-side-swipes-president-trump-s-leadership-ski?utm_medium=RSS&utm_campaign=news"
+        },
+        "permalink": "https://www.npr.org/2019/08/28/755018189/in-book-former-defense-chief-mattis-side-swipes-president-trump-s-leadership-ski?utm_medium=RSS&utm_campaign=news",
+        "content:encoded": {
+          "@": {},
+          "#": "<img src='https://media.npr.org/assets/img/2019/08/28/gettyimages-1074493698_wide-d77a974046aaf94c8bd37c8083750e56ee67606a.jpg?s=600' alt='James Mattis, then U.S. secretary of defense, leaves a news conference following a meeting about U.S.-China diplomacy and security at the State Department in Washington, D.C., in June 2017. Mattis' new book, Call Sign Chaos, implies criticism of President Trump without taking direct shots at him.'/><p>In the general's upcoming leadership book,<em> Call Sign Chaos,</em> the Obama administration catches the most flak. Mattis barely mentions President Trump but implies criticism of the sitting president.</p><p>(Image credit: Bloomberg via Getty Images)</p><img src='https://media.npr.org/include/images/tracking/npr-rss-pixel.png?story=755018189' />"
+        },
+        "dc:creator": {
+          "@": {},
+          "#": "David Welna"
+        }
+      };
+
+      let wiredSample = {
+        "title": "Fitbit Premium, Versa 2, Aria Air: Pricing, Specs, Details",
+        "description": "The company’s new offerings include two fitness-tracking products, a subscription service for personalized health advice, and lots and lots of partnerships.",
+        "summary": "The company’s new offerings include two fitness-tracking products, a subscription service for personalized health advice, and lots and lots of partnerships.",
+        "date": "2019-08-28T13:00:00.000Z",
+        "pubdate": "2019-08-28T13:00:00.000Z",
+        "pubDate": "2019-08-28T13:00:00.000Z",
+        "link": "https://www.wired.com/story/fitbit-versa-2-aria-air-smart-scale-fitbit-premium",
+        "author": "Adrienne So",
+        "image": {
+          "url": "https://media.wired.com/photos/5d65a6d443e62000086148e5/master/pass/Gear-Fitbit_Versa_2-Lead.jpg"
+        },
+        "enclosures": [
+          {
+            "url": null,
+            "type": null,
+            "length": null
+          }
+        ],
+        "media:content": {
+          "@": {}
+        },
+        "rss:description": {
+          "@": {},
+          "#": "The company’s new offerings include two fitness-tracking products, a subscription service for personalized health advice, and lots and lots of partnerships."
+        },
+        "dc:creator": {
+          "@": {},
+          "#": "Adrienne So"
+        },
+        "media:thumbnail": {
+          "@": {
+            "url": "https://media.wired.com/photos/5d65a6d443e62000086148e5/master/pass/Gear-Fitbit_Versa_2-Lead.jpg",
+            "width": "2400",
+            "height": "1800"
+          }
+        }
+      };
+
+      let espnSample = {
+        "title": "Kobe: 'Nothin but love' for Shaq after drama",
+        "description": "Kobe Bryant and Shaquille O'Neal, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym.",
+        "summary": "Kobe Bryant and Shaquille O'Neal, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym.",
+        "date": "2019-08-28T19:27:14.000Z",
+        "pubdate": "2019-08-28T19:27:14.000Z",
+        "pubDate": "2019-08-28T19:27:14.000Z",
+        "link": "http://www.espn.com/nba/story/_/id/27485035/kobe-nothin-love-shaq-drama",
+        "guid": "27485035",
+        "author": null,
+        "image": {},
+        "source": {},
+        "categories": [],
+        "enclosures": [],
+        "rss:@": {},
+        "rss:title": {
+          "@": {},
+          "#": "Kobe: 'Nothin but love' for Shaq after drama"
+        },
+        "rss:description": {
+          "@": {},
+          "#": "Kobe Bryant and Shaquille O'Neal, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym."
+        },
+        "rss:image": {
+          "@": {},
+          "#": "https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.jpg"
+        },
+        "rss:link": {
+          "@": {},
+          "#": "http://www.espn.com/nba/story/_/id/27485035/kobe-nothin-love-shaq-drama"
+        },
+        "rss:pubdate": {
+          "@": {},
+          "#": "Wed, 28 Aug 2019 14:27:14 EST"
+        }
+      };
+    </script>
+  </body>
+</html>

--- a/test/feed-formatter-test.html
+++ b/test/feed-formatter-test.html
@@ -51,7 +51,7 @@
             assert.equal(formatter.formatFeed(nprSample).description, "In the general's upcoming leadership book,<em> Call Sign Chaos,</em> the Obama administration catches the most flak. Mattis barely mentions President Trump but implies criticism of the sitting president.");
             assert.equal(formatter.formatFeed(wiredSample).description, "The company’s new offerings include two fitness-tracking products, a subscription service for personalized health advice, and lots and lots of partnerships.");
             assert.equal(formatter.formatFeed(espnSample).description, "Kobe Bryant and Shaquille O'Neal, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym.");
-            assert.equal(formatter.formatFeed(onionSample).description, "<p>BREVARD COUNTY, FL—Trying to hold back laughter while explaining how the garments were knit out of “proprietary NASA materials that are specially optimized for zero gravity,” Buzz Aldrin was reportedly selling a pair of old gym socks for $500,000 to a complete sucker Thursday, assuring him that he “totally” wore them…</p><p></p>");
+            assert.equal(formatter.formatFeed(onionSample).description, "<p>BREVARD COUNTY, FL—Trying to hold back laughter while explaining how the garments were knit out of “proprietary NASA materials that are specially optimized for zero gravity,” Buzz Aldrin was reportedly selling a pair of old gym socks for $500,000 to a complete sucker Thursday, assuring him that he “totally” wore them…</p><p><a href=\"https://www.theonion.com/yeah-i-totally-wore-these-on-the-moon-says-buzz-ald-1837705228\">Read more...</a></p>");
           });
         });
 

--- a/test/feed-formatter-test.html
+++ b/test/feed-formatter-test.html
@@ -119,6 +119,32 @@
             assert.equal(formatter._getBestImage(["image.pdf"]), null);
           });
         });
+
+        suite("_extractImages", () => {
+          test("should extract image urls from provided HTML", () => {
+            let html = "<img src='https://media.npr.org/image1.jpg' alt='Poorly formatted source's alt text'/><p>Paragraph 1</p><p>(Image credit: Bloomberg via Getty Images)</p><img src='https://media.npr.org/image2.png' />";
+            let images = ["https://media.npr.org/image1.jpg", "https://media.npr.org/image2.png"];
+
+            assert.deepEqual(formatter._extractImages(html), images);
+          });
+        });
+
+        suite("_removeElements", () => {
+          test("should remove the images from the provided HTML", () => {
+            let html = "<img src='https://media.npr.org/image1.jpg' alt='Poorly formatted source's alt text'/><p>Paragraph 1</p><p>(Image credit: Bloomberg via Getty Images)</p><img src='https://media.npr.org/image2.png' />";
+            let html2 = "<p>Paragraph 1</p><p>(Image credit: Bloomberg via Getty Images)</p>";
+
+            assert.deepEqual(formatter._removeElements(html, "img"), html2);
+          });
+
+          test("should remove the images and links from the provided HTML", () => {
+            let html = "<img src=\"https://i.kinja-img.com/image1.jpg\" /><p>BREVARD COUNTY, FL—Trying to hold back laughter while explaining how the garments were knit out of “proprietary NASA materials that are specially optimized for zero gravity,” Buzz Aldrin was reportedly selling a pair of old gym socks for $500,000 to a complete sucker Thursday, assuring him that he “totally” wore them…</p><p><a href=\"https://www.theonion.com/yeah-i-totally-wore-these-on-the-moon-says-buzz-ald-1837705228\">Read more...</a></p>";
+            let html2 = "<p>BREVARD COUNTY, FL—Trying to hold back laughter while explaining how the garments were knit out of “proprietary NASA materials that are specially optimized for zero gravity,” Buzz Aldrin was reportedly selling a pair of old gym socks for $500,000 to a complete sucker Thursday, assuring him that he “totally” wore them…</p><p></p>";
+            let htmlWithoutImages = formatter._removeElements(html, "img");
+
+            assert.deepEqual(formatter._removeElements(htmlWithoutImages, "a"), html2);
+          });
+        });
       });
 
       let nprSample = {

--- a/test/feed-formatter-test.html
+++ b/test/feed-formatter-test.html
@@ -41,6 +41,7 @@
             assert.equal(formatter.formatFeed(nprSample).title, "In Book, Former Defense Chief Mattis Sideswipes President Trump's Leadership Skills");
             assert.equal(formatter.formatFeed(wiredSample).title, "Fitbit Premium, Versa 2, Aria Air: Pricing, Specs, Details");
             assert.equal(formatter.formatFeed(espnSample).title, "Kobe: 'Nothin but love' for Shaq after drama");
+            assert.equal(formatter.formatFeed(onionSample).title, "‘Yeah, I Totally Wore These On The Moon,’ Says Buzz Aldrin Selling Old Pair Of Gym Socks To Complete Sucker For $500,000");
           });
         });
 
@@ -50,6 +51,7 @@
             assert.equal(formatter.formatFeed(nprSample).description, "In the general's upcoming leadership book,<em> Call Sign Chaos,</em> the Obama administration catches the most flak. Mattis barely mentions President Trump but implies criticism of the sitting president.");
             assert.equal(formatter.formatFeed(wiredSample).description, "The company’s new offerings include two fitness-tracking products, a subscription service for personalized health advice, and lots and lots of partnerships.");
             assert.equal(formatter.formatFeed(espnSample).description, "Kobe Bryant and Shaquille O'Neal, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym.");
+            assert.equal(formatter.formatFeed(onionSample).description, "<p>BREVARD COUNTY, FL—Trying to hold back laughter while explaining how the garments were knit out of “proprietary NASA materials that are specially optimized for zero gravity,” Buzz Aldrin was reportedly selling a pair of old gym socks for $500,000 to a complete sucker Thursday, assuring him that he “totally” wore them…</p><p></p>");
           });
         });
 
@@ -59,6 +61,7 @@
             assert.equal(formatter.formatFeed(nprSample).link, "https://www.npr.org/2019/08/28/755018189/in-book-former-defense-chief-mattis-side-swipes-president-trump-s-leadership-ski?utm_medium=RSS&utm_campaign=news");
             assert.equal(formatter.formatFeed(wiredSample).link, "https://www.wired.com/story/fitbit-versa-2-aria-air-smart-scale-fitbit-premium");
             assert.equal(formatter.formatFeed(espnSample).link, "http://www.espn.com/nba/story/_/id/27485035/kobe-nothin-love-shaq-drama");
+            assert.equal(formatter.formatFeed(onionSample).link, "https://www.theonion.com/yeah-i-totally-wore-these-on-the-moon-says-buzz-ald-1837705228");
           });
         });
 
@@ -68,6 +71,7 @@
             assert.equal(formatter.formatFeed(nprSample).imageUrl, "https://media.npr.org/assets/img/2019/08/28/gettyimages-1074493698_wide-d77a974046aaf94c8bd37c8083750e56ee67606a.jpg?s=600");
             assert.equal(formatter.formatFeed(wiredSample).imageUrl, "https://media.wired.com/photos/5d65a6d443e62000086148e5/master/pass/Gear-Fitbit_Versa_2-Lead.jpg");
             assert.equal(formatter.formatFeed(espnSample).imageUrl, "https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.jpg");
+            assert.equal(formatter.formatFeed(onionSample).imageUrl, "https://i.kinja-img.com/gawker-media/image/upload/s--Mn-kHCtr--/c_fit,fl_progressive,q_80,w_636/creypf6zoo2lwciap0k6.jpg");
           });
         });
 
@@ -77,6 +81,7 @@
             assert.equal(formatter.formatFeed(nprSample).author, "David Welna");
             assert.equal(formatter.formatFeed(wiredSample).author, "Adrienne So");
             assert.equal(formatter.formatFeed(espnSample).author, null);
+            assert.equal(formatter.formatFeed(onionSample).author, "The Onion");
           });
         });
 
@@ -86,6 +91,7 @@
             assert.equal(formatter.formatFeed(nprSample).pubDate, "2019-08-28T17:52:00.000Z");
             assert.equal(formatter.formatFeed(wiredSample).pubDate, "2019-08-28T13:00:00.000Z");
             assert.equal(formatter.formatFeed(espnSample).pubDate, "2019-08-28T19:27:14.000Z");
+            assert.equal(formatter.formatFeed(onionSample).pubDate, "2019-08-29T15:00:00.000Z");
           });
         });
 
@@ -257,6 +263,48 @@
         "rss:pubdate": {
           "@": {},
           "#": "Wed, 28 Aug 2019 14:27:14 EST"
+        }
+      };
+
+      let onionSample = {
+        "title": "‘Yeah, I Totally Wore These On The Moon,’ Says Buzz Aldrin Selling Old Pair Of Gym Socks To Complete Sucker For $500,000",
+        "description": "<img src=\"https://i.kinja-img.com/gawker-media/image/upload/s--Mn-kHCtr--/c_fit,fl_progressive,q_80,w_636/creypf6zoo2lwciap0k6.jpg\" /><p>BREVARD COUNTY, FL—Trying to hold back laughter while explaining how the garments were knit out of “proprietary NASA materials that are specially optimized for zero gravity,” Buzz Aldrin was reportedly selling a pair of old gym socks for $500,000 to a complete sucker Thursday, assuring him that he “totally” wore them…</p><p><a href=\"https://www.theonion.com/yeah-i-totally-wore-these-on-the-moon-says-buzz-ald-1837705228\">Read more...</a></p>",
+        "summary": "<img src=\"https://i.kinja-img.com/gawker-media/image/upload/s--Mn-kHCtr--/c_fit,fl_progressive,q_80,w_636/creypf6zoo2lwciap0k6.jpg\" /><p>BREVARD COUNTY, FL—Trying to hold back laughter while explaining how the garments were knit out of “proprietary NASA materials that are specially optimized for zero gravity,” Buzz Aldrin was reportedly selling a pair of old gym socks for $500,000 to a complete sucker Thursday, assuring him that he “totally” wore them…</p><p><a href=\"https://www.theonion.com/yeah-i-totally-wore-these-on-the-moon-says-buzz-ald-1837705228\">Read more...</a></p>",
+        "date": "2019-08-29T15:00:00.000Z",
+        "pubdate": "2019-08-29T15:00:00.000Z",
+        "pubDate": "2019-08-29T15:00:00.000Z",
+        "link": "https://www.theonion.com/yeah-i-totally-wore-these-on-the-moon-says-buzz-ald-1837705228",
+        "author": "The Onion",
+        "comments": null,
+        "origlink": null,
+        "image": {},
+        "enclosures": [],
+        "rss:@": {},
+        "rss:title": {
+          "@": {},
+          "#": "‘Yeah, I Totally Wore These On The Moon,’ Says Buzz Aldrin Selling Old Pair Of Gym Socks To Complete Sucker For $500,000"
+        },
+        "rss:link": {
+          "@": {},
+          "#": "https://www.theonion.com/yeah-i-totally-wore-these-on-the-moon-says-buzz-ald-1837705228"
+        },
+        "rss:description": {
+          "@": {},
+          "#": "<img src=\"https://i.kinja-img.com/gawker-media/image/upload/s--Mn-kHCtr--/c_fit,fl_progressive,q_80,w_636/creypf6zoo2lwciap0k6.jpg\" /><p>BREVARD COUNTY, FL—Trying to hold back laughter while explaining how the garments were knit out of “proprietary NASA materials that are specially optimized for zero gravity,” Buzz Aldrin was reportedly selling a pair of old gym socks for $500,000 to a complete sucker Thursday, assuring him that he “totally” wore them…</p><p><a href=\"https://www.theonion.com/yeah-i-totally-wore-these-on-the-moon-says-buzz-ald-1837705228\">Read more...</a></p>"
+        },
+        "rss:pubdate": {
+          "@": {},
+          "#": "Thu, 29 Aug 2019 15:00:00 GMT"
+        },
+        "rss:guid": {
+          "@": {
+            "ispermalink": "false"
+          },
+          "#": "1837705228"
+        },
+        "dc:creator": {
+          "@": {},
+          "#": "The Onion"
         }
       };
     </script>

--- a/test/feed-formatter-test.html
+++ b/test/feed-formatter-test.html
@@ -89,17 +89,34 @@
           });
         });
 
-        suite("_isValidImage", () => {
-          test("should return true for valid images", () => {
-            assert.isTrue(formatter._isValidImage("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.jpg"));
-            assert.isTrue(formatter._isValidImage("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.png"));
-            assert.isTrue(formatter._isValidImage("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.jpg?test=1"));
+        suite("_isPreferredFormat", () => {
+          test("should return true for preferred formats", () => {
+            assert.isTrue(formatter._isPreferredFormat("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.jpg"));
+            assert.isTrue(formatter._isPreferredFormat("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.png"));
+            assert.isTrue(formatter._isPreferredFormat("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.jpg?test=1"));
           });
 
-          test("should return false for non valid images", () => {
-            assert.isFalse(formatter._isValidImage("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.gif"));
-            assert.isFalse(formatter._isValidImage("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.pdf"));
-            assert.isFalse(formatter._isValidImage("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.gif?test=1"));
+          test("should return true for alt formats", () => {
+            assert.isTrue(formatter._isAltFormat("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.gif"));
+            assert.isTrue(formatter._isAltFormat("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.bmp?test=1"));
+          });
+
+          test("should return false for invalid images", () => {
+            assert.isFalse(formatter._isPreferredFormat("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.gif"));
+            assert.isFalse(formatter._isPreferredFormat("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.gif?test=1"));
+            assert.isFalse(formatter._isAltFormat("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.jpg"));
+            assert.isFalse(formatter._isAltFormat("https://a.espncdn.com/photo/2016/1101/r147434_600x400_3-2.jpg?test=1"));
+          });
+        });
+
+        suite("_getBestImage", () => {
+          test("should return true for valid images", () => {
+            assert.equal(formatter._getBestImage([]), null);
+            assert.equal(formatter._getBestImage(["image.jpg"]), "image.jpg");
+            assert.equal(formatter._getBestImage(["image.jpg", "image.gif"]), "image.jpg");
+            assert.equal(formatter._getBestImage(["image.gif", "image.jpg"]), "image.jpg");
+            assert.equal(formatter._getBestImage(["image.gif", "image.pdf"]), "image.gif");
+            assert.equal(formatter._getBestImage(["image.pdf"]), null);
           });
         });
       });

--- a/test/index.html
+++ b/test/index.html
@@ -13,7 +13,8 @@
   <script>
     // Load and run all tests (.html, .js):
     WCT.loadSuites([
-      'rise-data-rss-test.html'
+      'rise-data-rss-test.html',
+      'feed-formatter-test.html'
     ]);
   </script>
 </body>

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -38,9 +38,16 @@
             title: "Title 1",
             description: "Description 1",
             image: {
-              url: "http://www.feedforall.com/ffalogo48x48.gif",
+              url: "http://www.feedforall.com/ffalogo48x48.png",
               title: "FeedForAll Sample Feed"
             }
+          }
+        ];
+        const formattedRssJson = [
+          {
+            title: "Title 1",
+            description: "Description 1",
+            imageUrl: "http://www.feedforall.com/ffalogo48x48.png",
           }
         ];
         const invalidRssJson = {
@@ -221,7 +228,7 @@
               assert.deepEqual(element.log.getCall(1).args[2], { cached: true });
               // Should send a data-update event
               assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
-              assert.deepEqual(element._sendEvent.getCall(0).args[1], validRssJson);
+              assert.deepEqual(JSON.stringify(element._sendEvent.getCall(0).args[1]), JSON.stringify(formattedRssJson));
 
               done();
             }, 30);
@@ -229,6 +236,9 @@
 
           test("should handle a valid response from feed-parser", done => {
             sandbox.stub(cacheMixin, "getCache").rejects();
+            // Do not format feed
+            sandbox.stub(element._feedFormatter, "formatFeed").callsFake(function (val) { return val; });
+
             window.fetch.resolves(new Response(JSON.stringify(validRssJson)));
 
             element.feedurl = sampleFeedUrl;
@@ -260,6 +270,9 @@
             });
 
             sandbox.stub(cacheMixin, "getCache").rejects();
+            // Do not format feed
+            sandbox.stub(element._feedFormatter, "formatFeed").callsFake(function (val) { return val; });
+
             window.fetch.resolves(new Response(JSON.stringify(largeRssJson)));
 
             element.maxitems = 15;


### PR DESCRIPTION
## Description
Returns a curated set of fields, which are extracted from the main RSS feed applying a few rules to find the content.

## Motivation and Context
Even though RSS is a (set of) standard(s), a lot of feeds do not really respect it and put the information wherever they prefer. This is more clear with images. As part of this PR, we also remove images from the `description` field, since it causes duplicates when using the feed in a presentation (I tried removing `a` tags too, but it resulted in missing pieces of text so I reverted that change).

Originally I was parsing tags manually but, since we're running in the browser and the included parser is miles better than whatever I can write as a regular expression, I chose to rely on it.

The distinction between _preferred_ and _alternative_ image formats is that we may find more than one image in a feed and, in general, I noticed `.gif` images are just logos of the feed provider and are not related to the post itself. In case a different image is not found, the `.gif` file is used (it just has lower priority).

## How Has This Been Tested?
I have used Charles to have these changes available for testing (since Apps staging uses `beta` and this is not merged to master yet) and used the following Presentation as the source of my tests: 
- https://apps-stage-7.risevision.com/templates/edit/0fc5c730-069f-43af-9d23-1d00e3f3d839/?cid=87977ab8-38b6-47fb-ad5e-256b8cc4b46d
I used the following list of RSS feeds to validate content was being extracted properly:
- https://blog.enplug.com/rss-news-feeds-office

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No

@santiagonoguez  @stulees please review