### PR TITLE
Remove style attributes from description field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Rise Data Rss",
   "scripts": {
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",

--- a/src/feed-formatter.js
+++ b/src/feed-formatter.js
@@ -32,6 +32,7 @@ export default class FeedFormatter {
 
     if (description) {
       description = this._removeElements(description, "img");
+      description = this._removeAttributes(description, "style");
     }
 
     return description;
@@ -128,6 +129,19 @@ export default class FeedFormatter {
       let tag = tags[i];
 
       tag.parentElement.removeChild(tag);
+    }
+
+    return content.innerHTML;
+  }
+
+  _removeAttributes (html, attributeName) {
+    let content = this._parseHTML(html);
+    let elements = content.querySelectorAll(":not([" + attributeName + "=''])");
+
+    for (var i = 0; i < elements.length; i++) {
+      var element = elements[i];
+
+      element.removeAttribute(attributeName);
     }
 
     return content.innerHTML;

--- a/test/feed-formatter-test.html
+++ b/test/feed-formatter-test.html
@@ -50,7 +50,7 @@
             assert.equal(formatter.formatFeed({}).description, null);
             assert.equal(formatter.formatFeed(nprSample).description, "In the general's upcoming leadership book,<em> Call Sign Chaos,</em> the Obama administration catches the most flak. Mattis barely mentions President Trump but implies criticism of the sitting president.");
             assert.equal(formatter.formatFeed(wiredSample).description, "The company’s new offerings include two fitness-tracking products, a subscription service for personalized health advice, and lots and lots of partnerships.");
-            assert.equal(formatter.formatFeed(espnSample).description, "Kobe Bryant and Shaquille O'Neal, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym.");
+            assert.equal(formatter.formatFeed(espnSample).description, "<p>Kobe Bryant and Shaquille O'Neal</p>, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym.");
             assert.equal(formatter.formatFeed(onionSample).description, "<p>BREVARD COUNTY, FL—Trying to hold back laughter while explaining how the garments were knit out of “proprietary NASA materials that are specially optimized for zero gravity,” Buzz Aldrin was reportedly selling a pair of old gym socks for $500,000 to a complete sucker Thursday, assuring him that he “totally” wore them…</p><p><a href=\"https://www.theonion.com/yeah-i-totally-wore-these-on-the-moon-says-buzz-ald-1837705228\">Read more...</a></p>");
           });
         });
@@ -231,8 +231,8 @@
 
       let espnSample = {
         "title": "Kobe: 'Nothin but love' for Shaq after drama",
-        "description": "Kobe Bryant and Shaquille O'Neal, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym.",
-        "summary": "Kobe Bryant and Shaquille O'Neal, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym.",
+        "description": "<p style=\"text-weight: bold;\">Kobe Bryant and Shaquille O'Neal</p>, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym.",
+        "summary": "<p style=\"text-weight: bold;\">Kobe Bryant and Shaquille O'Neal</p>, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym.",
         "date": "2019-08-28T19:27:14.000Z",
         "pubdate": "2019-08-28T19:27:14.000Z",
         "pubDate": "2019-08-28T19:27:14.000Z",
@@ -250,7 +250,7 @@
         },
         "rss:description": {
           "@": {},
-          "#": "Kobe Bryant and Shaquille O'Neal, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym."
+          "#": "<p style=\"text-weight: bold;\">Kobe Bryant and Shaquille O'Neal</p>, who won three titles together with the Lakers, were trending after a quote from Bryant on July 29 surfaced, saying he could have had \"12 rings\" if O'Neal spent more time in the gym."
         },
         "rss:image": {
           "@": {},


### PR DESCRIPTION
## Description
This removes the `style` attributes from the provided `description` field. 

## Motivation and Context
It reduces possible issues of styling with some feeds (e.g., https://blog.thecenterforsalesstrategy.com/rss.xml).

## How Has This Been Tested?
Tested using Charles with a local version of the component.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@santiagonoguez please review
