### PR TITLE
E2e/cache refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#e2e/cache-refresh",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.1.0",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.8",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#e2e/cache-refresh",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -77,7 +77,6 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
 
     super.initCache({
       name: this.tagName.toLowerCase(),
-      duration: 1000 * 60 * 4.5, // Timers are not precise; we want fetch to retrieve fresh data every five minutes
       expiry: -1
     });    
   }

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -329,7 +329,7 @@
             let errorMessage = "Failed to connect to feed-parser";
 
             sandbox.stub(cacheMixin, "getCache").rejects();
-            sandbox.stub(fetchMixin, "_isOffline").resolves(false);
+            sandbox.stub(riseElement, "isOffline").resolves(false);
             sandbox.stub(fetchMixin, "_isMaxRetryAttempt").returns(true);
 
             window.fetch.rejects({ message: errorMessage });
@@ -359,7 +359,7 @@
 
             sandbox.stub(element, "_handleResponse");
             sandbox.stub(cacheMixin, "getCache").rejects();
-            sandbox.stub(fetchMixin, "_isOffline").resolves(true);
+            sandbox.stub(riseElement, "isOffline").resolves(true);
             sandbox.stub(fetchMixin, "_isMaxRetryAttempt").returns(true);
             window.fetch.rejects({ message: errorMessage });
 


### PR DESCRIPTION
## Description
No longer set cacheMixin `duration` value
Duration value is now defaulted to fetchMixin `refresh` value
Takes into account timeout inconsistencies (cache refresh is `5s` less than fetch)

Update `rise-common-component` version to latest
Cache `duration` is renamed to `refresh`

## Motivation and Context
Simplify mixin set up and remove confusion regarding 2 variables that do the same thing with 2 different names

## How Has This Been Tested?
Updated unit tests. Validated in the local environment using Charles proxy

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
