### PR TITLE
Updated cacheMixin version falls back to localStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.1.0",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#e2e/cache-fallback",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Rise Data Rss",
   "scripts": {
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",
@@ -28,7 +28,7 @@
   "dependencies": {
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#e2e/cache-fallback",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.2.0",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
Updated cacheMixin version falls back to localStorage

## Motivation and Context
Fixes issue where cache is not available in http

## How Has This Been Tested?
Validated on Chrome OS where we use http for Viewer mode locally via Charles proxy.

Discovered another unrelated issue which was logged for this repo #17 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No