### PR TITLE
Do not return imageUrl if offline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Rise Data Rss",
   "scripts": {
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Rise Data Rss",
   "scripts": {
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -111,10 +111,12 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
 
   _handleResponse(response) {
     response.json()
-      .then(this._processRssData.bind(this));
+      .then( json => {
+        this._processRssData(json, response.isOffline);
+      });
   }
 
-  _processRssData(data) {
+  _processRssData(data, isOffline) {
     if (!data.Error) {
       let slicedData = data.slice(0, this.maxitems);
 
@@ -125,7 +127,13 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
         this.log( "info", "data provided" );
 
         this._sendRssEvent(RiseDataRss.EVENT_DATA_UPDATE, this.feedData.map( item => {
-          return this._feedFormatter.formatFeed(item);
+          let formattedFeed = this._feedFormatter.formatFeed(item);
+
+          if (isOffline) {
+            formattedFeed.imageUrl = null;
+          }
+
+          return formattedFeed;
         }));
       }
     }

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -203,6 +203,18 @@
             assert.isTrue(element._sendRssEvent.calledOnce);
             assert.isTrue(element._latestFailed);
           });
+
+          test("should provide imageUrl if online", () => {
+            element._processRssData([{ title: "Title 1", image: { url: "imageUrl" } }]);
+
+            assert.equal(JSON.stringify(element._sendRssEvent.getCall(0).args[1]), JSON.stringify([{ title: "Title 1", imageUrl: "imageUrl" }]));
+          });
+
+          test("should not provide imageUrl if offline", () => {
+            element._processRssData([{ title: "Title 1", image: { url: "imageUrl" } }], true);
+
+            assert.equal(JSON.stringify(element._sendRssEvent.getCall(0).args[1]), JSON.stringify([{ title: "Title 1", imageUrl: null }]));
+          });
         });
 
         suite("_loadFeedData", () => {
@@ -228,7 +240,7 @@
               assert.deepEqual(element.log.getCall(1).args[2], { cached: true });
               // Should send a data-update event
               assert.equal(element._sendEvent.getCall(0).args[0], "data-update");
-              assert.deepEqual(JSON.stringify(element._sendEvent.getCall(0).args[1]), JSON.stringify(formattedRssJson));
+              assert.equal(JSON.stringify(element._sendEvent.getCall(0).args[1]), JSON.stringify(formattedRssJson));
 
               done();
             }, 30);


### PR DESCRIPTION
## Description
Removes `imageUrl` from the provided data if operating offline.

## Motivation and Context
Presentations running offline would show a broken image link.

## How Has This Been Tested?
Used Charles and VMWare Fusion to run a real presentation.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@stulees please review