### PR TITLE
Downgrade errors to warnings when caused by feed provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The component sends the following events:
 
 - **configured**: The component has initialized what it requires to and is ready to handle a _start_ event.
 - **data-update**: An event proving a maximum of _max-items_ elements from the provided feed-url. This event will be generated on startup and whenever data on the feed has changed; if the feed has not changed since the last refresh, an event will not be generated. The data object is provided in `event.details`. The response format can be checked [here](https://www.npmjs.com/package/feedparser#what-is-the-parsed-output-produced-by-feedparser).
-- **data-error**: An event indicating the feed responded with an error (i.e. feed format, etc). An error object is provided in `event.details`.
+- **data-error**: An event indicating the feed responded with an error. An error object is provided in `event.details`.
+- **feed-provider-error**: An event indicating there were issues contacting the feed (establishing connection, timeout or bad data). An error object is provided in `event.details`.
 - **request-error**: An event indicating there were problems requesting the feed. An error object is provided in `event.details`.
 
 The component listens for the following events:
@@ -66,6 +67,7 @@ The component logs the following events to BQ:
 - **data received**: The component successfully retrieved data from the feed.
 - **data provided**: The component detected new data from the feed and provided it to the client.
 - **data error**: The component received an error from feed-parser. The details of the error will be provided as part of the log.
+- **feed provider error**: The component received an error from the feed. The details of the error will be provided as part of the log.
 - **request error**: The component was not able to connect to feed-parser.
 - **client offline**: The component was not able to connect to feed-parser because the client has connectivity issues.
 

--- a/demo/src/rise-data-rss.html
+++ b/demo/src/rise-data-rss.html
@@ -128,6 +128,15 @@
         document.querySelector('#rssErrors').innerHTML = JSON.stringify(error);
       });
 
+      riseDataRSS01.addEventListener("feed-provider-error", error => {
+        console.log("There were problems with the feed provider", error);
+
+        document.querySelector('#rssErrors').style.display = "block";
+        document.querySelector('#rssFeed').style.display = "none";
+
+        document.querySelector('#rssErrors').innerHTML = JSON.stringify(error);
+      });
+
       riseDataRSS01.addEventListener("request-error", error => {
         console.log("Failed to connect to feed-parser", error);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.7",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -989,8 +989,8 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#c6efee0d50d1d994ef0975d39124014cb49dae0e",
-      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.1.0",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#8ba02ff7c389708945320146c5b9c8eedbddbefa",
+      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.2.0",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "^2.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Rise Data Rss",
   "scripts": {
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",

--- a/src/rise-data-rss.js
+++ b/src/rise-data-rss.js
@@ -174,10 +174,10 @@ export default class RiseDataRss extends FetchMixin(fetchBase) {
     switch (name) {
     case RiseDataRss.EVENT_REQUEST_ERROR:
     case RiseDataRss.EVENT_DATA_ERROR:
-    case RiseDataRss.EVENT_FEED_PROVIDER_ERROR:
       super._setUptimeError(true);
       break;
     case RiseDataRss.EVENT_DATA_UPDATE:
+    case RiseDataRss.EVENT_FEED_PROVIDER_ERROR:
       super._setUptimeError(false);
       break;
     default:

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -354,7 +354,7 @@
               assert.equal(window.fetch.args[0][0], sampleServerUrl + sampleFeedUrl);
 
               setTimeout(() => {
-                assert.isTrue(riseElement._setUptimeError.calledWith(true));
+                assert.isTrue(riseElement._setUptimeError.calledWith(false));
 
                 // Should log the received data
                 assert.equal(element.log.getCall(1).args[1], "data received");

--- a/test/rise-data-rss-test.html
+++ b/test/rise-data-rss-test.html
@@ -53,6 +53,9 @@
         const invalidRssJson = {
           Error: "An error has occurred"
         };
+        const eConnResetJson = {
+          Error: "ECONNRESET"
+        };
         let sandbox = sinon.createSandbox();
         let element;
         let fetchMixin, cacheMixin, riseElement, loggerMixin;
@@ -340,6 +343,38 @@
             });
           });
 
+          test("should handle an error from a feed provider", done => {
+            sandbox.stub(cacheMixin, "getCache").rejects();
+            window.fetch.resolves(new Response(JSON.stringify(eConnResetJson)));
+
+            element.feedurl = sampleFeedUrl;
+
+            setTimeout(() => {
+              assert.isTrue(window.fetch.called);
+              assert.equal(window.fetch.args[0][0], sampleServerUrl + sampleFeedUrl);
+
+              setTimeout(() => {
+                assert.isTrue(riseElement._setUptimeError.calledWith(true));
+
+                // Should log the received data
+                assert.equal(element.log.getCall(1).args[1], "data received");
+                assert.deepEqual(element.log.getCall(1).args[2], { cached: false });
+                // Should log the warning data
+                assert.equal(element.log.getCall(2).args[0], "warning");
+                assert.equal(element.log.getCall(2).args[1], "feed provider error");
+                assert.deepEqual(element.log.getCall(2).args[2], {
+                  feed: "https://www.feedforall.com/sample.xml",
+                  error: eConnResetJson.Error
+                });
+                // Should send a feed-provider-error event
+                assert.equal(element._sendEvent.getCall(0).args[0], "feed-provider-error");
+                assert.deepEqual(element._sendEvent.getCall(0).args[1], { error: eConnResetJson.Error });
+
+                done();
+              }, 20);
+            });
+          });
+
           test("should handle failure to connect to feed-parser", done => {
             let errorMessage = "Failed to connect to feed-parser";
 
@@ -392,6 +427,19 @@
                 done();
               }, 20);
             });
+          });
+        });
+
+        suite("_isFeedProviderError", () => {
+          test("should return true if it is a feed provider error", () => {
+            assert.isTrue(element._isFeedProviderError("ETIMEDOUT"));
+            assert.isTrue(element._isFeedProviderError("ECONNRESET"));
+            assert.isTrue(element._isFeedProviderError("Parse Error"));
+          });
+
+          test("should return false if it is not a feed provider error", () => {
+            assert.isFalse(element._isFeedProviderError("Invalid url"));
+            assert.isFalse(element._isFeedProviderError());
           });
         });
       });


### PR DESCRIPTION
## Description
Downgrades `errors` caused by problems in the feed provider to `warnings`

## Motivation and Context
Our reliability is not reflecting real problems with our component or `feed-parser`, but with the feeds selected by users (over which we don't have control). We will still keep an eye on warnings, but problems caused by feeds will not count towards our reliability.

## How Has This Been Tested?
Unit tests were added and the existing ones passed without modifications. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@stulees @santiagonoguez please review
