### PR TITLE
Add Coveralls support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
           key: node-cache-{{ checksum "package.json" }}
       - run: sudo npm install -g wct-istanbul
       - run: npm test
+      - run: cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
   build:
     docker: *BUILDIMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
       - run: sudo npm install -g wct-istanbul
-      - run: npm run testci
+      - run: npm test
 
   build:
     docker: *BUILDIMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
       - run: sudo npm install -g wct-istanbul
-      - run: npm testci
+      - run: npm run testci
 
   build:
     docker: *BUILDIMAGE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
       - checkout
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
+      - run: sudo npm install -g wct-istanbul
       - run: npm test
 
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
       - run: sudo npm install -g wct-istanbul
-      - run: npm test
+      - run: npm testci
 
   build:
     docker: *BUILDIMAGE

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 demo/build/
 demo/node_modules/
 src/rise-data-rss-config.js
+coverage/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rise Data Rss [![CircleCI](https://circleci.com/gh/Rise-Vision/rise-data-rss/tree/master.svg?style=svg)](https://circleci.com/gh/Rise-Vision/rise-data-rss/tree/master)
+# Rise Data Rss [![CircleCI](https://circleci.com/gh/Rise-Vision/rise-data-rss/tree/master.svg?style=svg)](https://circleci.com/gh/Rise-Vision/rise-data-rss/tree/master) [![Coverage Status](https://coveralls.io/repos/github/Rise-Vision/rise-data-rss/badge.svg?branch=master)](https://coveralls.io/github/Rise-Vision/rise-data-rss?branch=master)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ Execute the following command in Terminal to run tests:
 npm run test
 ```
 
+In case `polymer-cli` was installed globally, the `wct-istanbul` package will also need to be installed globally:
+
+```
+npm install -g wct-istanbul
+```
+
 #### Local Server
 Run the following command in Terminal: `polymer serve`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Rise Data Rss",
   "scripts": {
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-utils": ">=1.4.1",
     "@polymer/test-fixture": "^4.0.2",
     "chai": "^4.2.0",
+    "coveralls": "3.0.6",
     "mocha": "^5.2.0",
     "sinon": "^7.3.2",
     "wct-mocha": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "coveralls": "3.0.6",
     "mocha": "^5.2.0",
     "sinon": "^7.3.2",
+    "wct-istanbul": "^0.14.3",
     "wct-mocha": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",
     "build": "polymer build && ./node_modules/rise-common-component/scripts/extract-source.sh rise-data-rss",
     "pretest": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh test rise-data-rss",
-    "test": "eslint . && polymer test"
+    "test": "eslint . && polymer test",
+    "testci": "eslint . && polymer test && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",
     "build": "polymer build && ./node_modules/rise-common-component/scripts/extract-source.sh rise-data-rss",
     "pretest": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh test rise-data-rss",
-    "test": "eslint . && polymer test",
-    "testci": "eslint . && polymer test && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "test": "eslint . && polymer test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.11",
+  "version": "1.0.10",
   "description": "Rise Data Rss",
   "scripts": {
     "prebuild": "eslint . && ./node_modules/rise-common-component/scripts/create_config.sh prod rise-data-rss",

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -5,15 +5,6 @@
   "plugins": {
     "local": {
       "browsers": ["chrome"]
-    },
-    "istanbul": {
-      "reporters": ["text", "text-summary", "lcov"],
-      "include": [
-        "**/src/**/*.js"
-      ],
-      "exclude": [
-        "**/test/**"
-      ]
     }
   }
 }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -13,7 +13,15 @@
       ],
       "exclude": [
         "**/test/**"
-      ]
+      ],
+      "thresholds": {
+        "global": {
+          "branches": 90,
+          "lines": 90,
+          "functions": 90,
+          "statements": 90
+        }
+      }
     }
   }
 }

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -5,6 +5,15 @@
   "plugins": {
     "local": {
       "browsers": ["chrome"]
+    },
+    "istanbul": {
+      "reporters": ["text", "text-summary", "lcov"],
+      "include": [
+        "**/src/**/*.js"
+      ],
+      "exclude": [
+        "**/test/**"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Description
Adds support for Coveralls reporting

## Motivation and Context
We don't have code coverage and we want to track if we're doing well in that area

## How Has This Been Tested?
Tests have been ran as part of the build and can be checked here: https://coveralls.io/github/Rise-Vision/rise-data-rss

I also ran the tests locally.  In case `polymer-cli` is installed globally, the `wct-istanbul` package needs to be installed globally too, otherwise Polymer will not find the dependency.

#### For reference
As a side note, in the original branch I had created a separate `testci` task that I was running with `npm run testci`. That task handled reporting to coveralls. Funnily enough, running the tests that way caused an issue with `sinon` that took me way too long to figure out: https://circleci.com/gh/Rise-Vision/rise-data-rss/836.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@stulees @santiagonoguez please review