### PR TITLE
Add new dist file that points to polymer-bundle.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-data-rss",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Rise Data Rss",
   "scripts": {
     "preinstall": "npx npm-force-resolutions || true",
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/Rise-Vision/rise-data-rss/#readme",
   "dependencies": {
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.1",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.9.2",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {


### PR DESCRIPTION

## Description
Adds an extra distribution file that references a static version of polymer and dependencies instead of relative to the template.

## Motivation and Context
Please check notes from: https://github.com/Rise-Vision/rise-common-component/pull/73

## How Has This Been Tested?
Confirmed the file exists and points to the static polymer-bundle: 
https://widgets.risevision.com/staging/components/rise-data-rss/build-bundle/rise-data-rss-bundle.min.js

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

@alexdeaconu Please review. 
@stulees @olegrise fyi
